### PR TITLE
Feat/minimal actuator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install -e .
-      - run: python -m unittest discover -s tests -v
+      - run: pip install -e ".[dev]"
+      - run: python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ Actuation (new — the control loop that drives disposable workers):
 - `Reconciler.reconcile_once` — one serialized, idempotent pass (INV-6) that
   actuates `READY` tasks, applies fenced worker receipts, adopts crashed
   workers, resumes unblocked `WAITING` tasks, and repairs the observed registry;
+- **crash-consistency**: desired authoritative state (RUNNING + lease) is
+  persisted BEFORE any external launch, so a reconciler crash between the two
+  never double-actuates; launch is idempotent per lease;
+- **grace policy**: a lease is rotated off a worker only when it is *durably*
+  dead (no receipt and no heartbeat within `grace_seconds`) — a single transient
+  liveness miss never revokes a live worker's lease (INV-5);
+- **single-reconciler lock** (`locking.single_reconciler`, flock): two
+  `farm reconcile` processes cannot race on one farm (INV-6);
+- every authoritative mutation — state transition AND lease acquire/rotate/
+  release — goes through one durable-write + event boundary (INV-7);
 - structured **receipt** primitive (`RUNNING`/`AWAITING`/`SUBMITTED`/`FAILED`),
   fenced by `lease_id` so a superseded worker generation cannot advance a task;
 - **lease rotation** (`rotate_lease`) — releases a lease from a *proven-dead*

--- a/README.md
+++ b/README.md
@@ -15,50 +15,51 @@ The design is derived from real failure modes in a live SSH/tmux/SLURM agent far
 
 ## Current status
 
-**Minimal actuator landed (canary stage). Codex/tmux backend still pending.**
+**v0.3 — actuation implemented and validated by real-codex canaries.** The
+contract in [`V2_DESIGN.md`](V2_DESIGN.md) is aligned to the code (§10 maps every
+invariant to its implementation). The next phase is running an isolated canary
+farm, not more feature development.
 
-Safe foundation (unchanged):
+Foundation:
 
-- task / worker / event models;
-- atomic durable task storage;
-- legal lifecycle validation;
-- lease/fencing validation helpers;
-- invariant checks (`farm doctor`);
-- read-only shadow observations (`farm shadow`);
-- cluster/project templates;
-- regression tests for the frozen invariants.
+- task / worker / event models; atomic durable task storage;
+- legal lifecycle validation; lease/fencing validation;
+- invariant checks (`farm doctor`); read-only shadow observations (`farm shadow`);
+- cluster/project templates; regression tests for the invariants.
 
-Actuation (new — the control loop that drives disposable workers):
+Actuation — the control loop that drives disposable workers:
 
 - `Reconciler.reconcile_once` — one serialized, idempotent pass (INV-6) that
   actuates `READY` tasks, applies fenced worker receipts, adopts crashed
   workers, resumes unblocked `WAITING` tasks, and repairs the observed registry;
-- **crash-consistency**: desired authoritative state (RUNNING + lease) is
-  persisted BEFORE any external launch, so a reconciler crash between the two
-  never double-actuates; launch is idempotent per lease;
-- **grace policy**: a lease is rotated off a worker only when it is *durably*
-  dead (no receipt and no heartbeat within `grace_seconds`) — a single transient
-  liveness miss never revokes a live worker's lease (INV-5);
-- **single-reconciler lock** (`locking.single_reconciler`, flock): two
-  `farm reconcile` processes cannot race on one farm (INV-6);
-- every authoritative mutation — state transition AND lease acquire/rotate/
-  release — goes through one durable-write + event boundary (INV-7);
-- structured **receipt** primitive (`RUNNING`/`AWAITING`/`SUBMITTED`/`FAILED`),
-  fenced by `lease_id` so a superseded worker generation cannot advance a task;
-- **lease rotation** (`rotate_lease`) — releases a lease from a *proven-dead*
-  holder so the task can be re-actuated with state preserved. This is the
-  "adopt a stopped task" primitive and is a **design delta beyond frozen v0.2**
-  (state graph froze before actuation), pending ratification into v0.3;
-- `WorkerExecutor` backends: `FakeExecutor` (tests) and `LocalProcessExecutor`
-  (drives real OS subprocesses — the honest bridge before a codex/tmux backend);
-- `farm reconcile [--loop]` CLI.
+- **crash-consistency** (INV-9): the authoritative RUNNING+lease is persisted
+  BEFORE any launch, and on adoption new ownership is committed BEFORE the stale
+  generation is stopped — so a reconciler crash never double-actuates or orphans
+  a task; launch is idempotent per lease;
+- **grace policy** (INV-10): a lease is rotated off a worker only when it is
+  *durably* dead (no receipt and no heartbeat within `--grace-seconds`) — a
+  single transient liveness miss never revokes a live worker's lease (INV-5);
+- **stable worker identity** (INV-11): liveness is a recorded `(pid, starttime)`
+  set at launch AND refreshed identically on resume — never a workspace-wide
+  process scan; a recycled pid or a resumed worker's dead original is never
+  mistaken for the live worker;
+- **single-reconciler lock** (`locking.single_reconciler`, flock, INV-6);
+- one authoritative-mutation boundary (INV-7): every state transition AND lease
+  acquire/rotate/release goes through a durable-write + event;
+- structured, atomically-written **receipt** primitive
+  (`RUNNING`/`AWAITING`/`SUBMITTED`/`FAILED`), fenced by `lease_id`;
+- **lease rotation** (`rotate_lease`) — the "adopt a stopped task" primitive,
+  ratified into the v0.3 contract; requires a `reason` establishing death and
+  can never rotate off a possibly-live holder;
+- **one active task per workspace** (INV-12): `doctor` FAILs on two active tasks
+  sharing a workspace;
+- `WorkerExecutor` backends: `FakeExecutor` (tests), `LocalProcessExecutor` (real
+  subprocesses), and **`CodexTmuxExecutor`** (real codex workers in a dedicated,
+  isolated tmux server; cluster specifics in `CodexClusterConfig`);
+- `farm reconcile [--executor codex-tmux] [--loop]` CLI.
 
-A worker never drives `DONE`: `DONE` still requires recorded acceptance, which
-is a master/harness judgment (Layer-1/Layer-2 boundary).
-
-Still deferred: the **codex/tmux executor backend** (real farm workers), SLURM
-job mutation, WAITING-condition observers (`job:`/`artifact:`/`task:`/`ruling:`),
-and enforcement against live (non-cooperative) workers.
+A worker never drives `DONE`: `DONE` still requires recorded acceptance, a
+master/harness judgment (Layer-1/Layer-2 boundary).
 
 ## Design rule
 
@@ -141,19 +142,18 @@ Cluster-specific behavior belongs behind adapters. The core task semantics shoul
 
 ## What is deliberately deferred
 
-- codex/tmux executor backend (real farm workers; `LocalProcessExecutor` is the
-  current real backend and the pattern to specialize);
+- WAITING-condition observers (`job:`/`artifact:`/`task:`/`ruling:` predicates):
+  the reconciler resumes on an injected `unblock` predicate; the observers that
+  evaluate those conditions are the next build item;
 - enforcement of leases against live *non-cooperative* workers (fencing today
   assumes workers echo their `lease_id`);
-- WAITING-condition observers (`job:`/`artifact:`/`task:`/`ruling:` predicates);
 - SLURM job submission/cancellation;
 - automatic scientific acceptance (DONE stays a master/harness judgment);
 - priority scheduling;
-- multi-master routing;
-- event stream as a signal bus;
-- global event sequence/cursors.
+- multi-master routing (`decision_owner`);
+- event stream as a signal bus; global event sequence/cursors.
 
-These should be introduced only when shadow/canary evidence requires them.
+These are introduced only when canary evidence requires them (see V2_DESIGN §10.5).
 
 ## Actuation quick start
 
@@ -170,13 +170,30 @@ The worker reads `FARM_RECEIPT_PATH`, `FARM_WORKER_ID`, `FARM_TASK_ID`,
 `FARM_LEASE_ID` from its environment and writes a JSON `Receipt` to
 `FARM_RECEIPT_PATH` when it reaches a wait boundary, submits, or fails.
 
+For real codex workers, create the task with `--workspace`/`--brief`(`--brief-file`)
+and drive it with the codex-tmux executor on a dedicated, isolated tmux server
+(never the live `farm` session):
+
+```bash
+farm --project P task-create --id T-1 \
+  --objective "..." --deliverable "..." --acceptance "..." \
+  --workspace /abs/workspace --brief-file BRIEF.md
+farm --project P reconcile --executor codex-tmux --session farm2 --tmux-socket canary
+```
+
+The executor drops a `.farm_receipt.py` helper into the workspace; the agent
+records `AWAITING`/`SUBMITTED`/`FAILED` with it (the helper echoes the lease id
+for fencing). Cluster specifics (PATH prelude, codex command) come from
+`CodexClusterConfig` / `FARM_CODEX_*` env, not the module.
+
 ## Tests
 
 ```bash
-python -m unittest discover -s tests -v
+pip install -e ".[dev]"
+python -m pytest -q
 ```
 
-The regression suite is intended to turn historical orchestration failures into permanent invariants.
+The regression suite turns historical orchestration failures (and each review finding) into permanent invariants.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The design is derived from real failure modes in a live SSH/tmux/SLURM agent far
 
 ## Current status
 
-**Shadow-first prototype. No production actuator is enabled.**
+**Minimal actuator landed (canary stage). Codex/tmux backend still pending.**
 
-This repository intentionally implements only the safe foundation:
+Safe foundation (unchanged):
 
 - task / worker / event models;
 - atomic durable task storage;
@@ -28,7 +28,27 @@ This repository intentionally implements only the safe foundation:
 - cluster/project templates;
 - regression tests for the frozen invariants.
 
-It does **not** yet replace a production nudger/watcher, start or kill workers, mutate SLURM jobs, or add a receipt/ACK protocol to existing workers.
+Actuation (new — the control loop that drives disposable workers):
+
+- `Reconciler.reconcile_once` — one serialized, idempotent pass (INV-6) that
+  actuates `READY` tasks, applies fenced worker receipts, adopts crashed
+  workers, resumes unblocked `WAITING` tasks, and repairs the observed registry;
+- structured **receipt** primitive (`RUNNING`/`AWAITING`/`SUBMITTED`/`FAILED`),
+  fenced by `lease_id` so a superseded worker generation cannot advance a task;
+- **lease rotation** (`rotate_lease`) — releases a lease from a *proven-dead*
+  holder so the task can be re-actuated with state preserved. This is the
+  "adopt a stopped task" primitive and is a **design delta beyond frozen v0.2**
+  (state graph froze before actuation), pending ratification into v0.3;
+- `WorkerExecutor` backends: `FakeExecutor` (tests) and `LocalProcessExecutor`
+  (drives real OS subprocesses — the honest bridge before a codex/tmux backend);
+- `farm reconcile [--loop]` CLI.
+
+A worker never drives `DONE`: `DONE` still requires recorded acceptance, which
+is a master/harness judgment (Layer-1/Layer-2 boundary).
+
+Still deferred: the **codex/tmux executor backend** (real farm workers), SLURM
+job mutation, WAITING-condition observers (`job:`/`artifact:`/`task:`/`ruling:`),
+and enforcement against live (non-cooperative) workers.
 
 ## Design rule
 
@@ -111,17 +131,34 @@ Cluster-specific behavior belongs behind adapters. The core task semantics shoul
 
 ## What is deliberately deferred
 
-- production worker launching/restarting;
-- enforcement of leases against live workers;
-- structured receipt/ACK protocol;
-- automatic scientific acceptance;
+- codex/tmux executor backend (real farm workers; `LocalProcessExecutor` is the
+  current real backend and the pattern to specialize);
+- enforcement of leases against live *non-cooperative* workers (fencing today
+  assumes workers echo their `lease_id`);
+- WAITING-condition observers (`job:`/`artifact:`/`task:`/`ruling:` predicates);
+- SLURM job submission/cancellation;
+- automatic scientific acceptance (DONE stays a master/harness judgment);
 - priority scheduling;
 - multi-master routing;
 - event stream as a signal bus;
-- global event sequence/cursors;
-- generic backend plugin framework beyond thin adapters.
+- global event sequence/cursors.
 
 These should be introduced only when shadow/canary evidence requires them.
+
+## Actuation quick start
+
+```bash
+farm --project P init
+farm --project P task-create --id T-1 \
+  --objective "..." --deliverable "..." --acceptance "..." \
+  --command "python my_worker.py"     # worker echoes FARM_LEASE_ID in its receipt
+farm --project P reconcile            # one pass: launch -> observe -> advance
+farm --project P doctor               # invariant check
+```
+
+The worker reads `FARM_RECEIPT_PATH`, `FARM_WORKER_ID`, `FARM_TASK_ID`,
+`FARM_LEASE_ID` from its environment and writes a JSON `Receipt` to
+`FARM_RECEIPT_PATH` when it reaches a wait boundary, submits, or fails.
 
 ## Tests
 

--- a/V2_DESIGN.md
+++ b/V2_DESIGN.md
@@ -1,17 +1,24 @@
-# V2_DESIGN.md — durable-state-driven farm runtime (v0.2)
+# V2_DESIGN.md — durable-state-driven farm runtime (v0.3)
 
-Status: DESIGN ONLY. No production code changes. This freezes the contract
-before implementation, the same discipline we apply to tasks
-(registration-before-execution). Derived from the empirical review of the
-2026-08-31 → 09-02 farm operation: every failure was in the ephemeral
-coordination layer (tmux, nudger, master session memory); durable on-disk
-state and decoupled SLURM compute never failed. V2 makes that separation
-deliberate: the coordination layer itself derives from durable state, so any
-actor (reconciler, master, worker) is reconstructable and replaceable.
+Status: CONTRACT ALIGNED TO IMPLEMENTATION. The minimal actuation layer is now
+implemented in `src/agent_farm_runtime/` and validated by real-codex canaries
+(launch, crash-adoption, resume; see §10). v0.2 was DESIGN ONLY; v0.3 pins the
+representations that implementation settled and RATIFIES the actuation semantics
+that v0.2 deferred (lease rotation, grace-based death detection, crash-consistent
+ordering, the structured receipt primitive). The next phase is NOT further
+feature development but running an isolated canary farm on this contract.
 
-Each section is marked **[FROZEN]** (semantics we commit to now) or
-**[PROVISIONAL]** (concrete representation, to be pinned during
-implementation and free to change without reopening the frozen contract).
+Derived from the empirical review of the 2026-08-31 → 09-02 farm operation:
+every failure was in the ephemeral coordination layer (tmux, nudger, master
+session memory); durable on-disk state and decoupled SLURM compute never failed.
+V2 makes that separation deliberate: the coordination layer itself derives from
+durable state, so any actor (reconciler, master, worker) is reconstructable and
+replaceable.
+
+Each section is marked **[FROZEN]** (semantics we commit to), **[PINNED v0.3]**
+(a representation implementation settled) or **[PROVISIONAL]** (still free to
+change without reopening the frozen contract). §10 maps every invariant and
+mechanism to the code that realizes it and lists what remains deferred.
 
 ---
 
@@ -79,6 +86,36 @@ Each is anchored to a real failure mode from the reviewed operation.
   consumer. *(duplicate event)* (Global monotonic SEQUENCE is deferred — see
   §5, to avoid inventing a new coordination race before events become a
   signal bus.)
+
+The following were introduced when actuation was implemented (v0.3); each is
+anchored to a concrete correctness risk found in review or canary.
+
+- **INV-9 Persist desired state before external actuation.** The authoritative
+  RUNNING+lease is committed to the Task Store BEFORE any worker is launched,
+  and on adoption the NEW ownership is committed BEFORE the stale generation is
+  stopped. A reconciler crash between the durable write and the external side
+  effect therefore never double-actuates and never orphans a task. Launch is
+  idempotent for a given lease. *(review: crash between actuation and store
+  write could relaunch work)*
+
+- **INV-10 Durable death before revocation (grace).** A lease is rotated off a
+  worker only when that worker is DURABLY dead: not observed alive AND no valid
+  receipt AND no heartbeat within a grace window. A single transient liveness
+  miss never revokes a live worker's lease (guards INV-5 from the observer
+  side). *(review: a transient pgrep/proc miss must not revoke a live worker)*
+
+- **INV-11 Stable worker identity.** A worker's liveness is judged by a stable
+  process identity — `(pid, starttime)` — recorded at launch AND refreshed
+  identically on resume, never by a workspace-wide process scan. A recycled pid
+  or a sibling process is never mistaken for the worker; a resumed worker is
+  tracked as its current process, not its dead original. *(review: resume left
+  liveness pointing at the dead original → false adoption; codex runs as
+  `node`, so name-based identity is wrong)*
+
+- **INV-12 One active task per workspace.** A workspace holds one agent's mutable
+  state (LEDGER, session id, master notes); at most one task in an active state
+  (RUNNING/WAITING) may reference a given workspace. `doctor` FAILs otherwise.
+  *(two workers in one workspace would corrupt each other's state)*
 
 ---
 
@@ -159,9 +196,23 @@ These are expected to change during implementation without reopening §1–§4.
 
 - **Concrete field sets** (below in §6) — minimal now; add only when an
   invariant demands it.
-- **File layout / storage** — where Task Store / Registry / Event Log physically
-  live (per-task JSON? one store file? sqlite?), locking mechanism for INV-6.
-- **Heartbeat timeout** and **reconciler polling cadence** — numbers TBD.
+- **File layout / storage** — **[PINNED v0.3]** project-local `.farm/`:
+  `tasks/<id>.json` (authoritative, atomic write via temp+fsync+rename),
+  `workers/<id>.json` (observed), `events/log.ndjson` (append-only),
+  `runtime/` (reconcile lock, per-worker executor state, receipts). INV-6
+  locking is a non-blocking `flock` on `runtime/reconcile.lock`. Not sqlite; a
+  single reconciler + atomic per-file writes suffice at farm scale.
+- **Heartbeat / grace** — **[PINNED v0.3]** death is declared only after a grace
+  window with no heartbeat and no receipt (INV-10); default 60s, operator-set
+  via `--grace-seconds`. **Reconciler cadence** — operator-set via
+  `reconcile --loop --interval` (no fixed number baked in).
+- **Structured receipt primitive** — **[PINNED v0.3]** the worker→runtime signal
+  deferred in v0.2 (§8/§9) is now real: a worker writes a fenced JSON
+  `Receipt {worker_id, task_id, lease_id, status: RUNNING|AWAITING|SUBMITTED|
+  FAILED, ts, note, waiting_on}` atomically; the reconciler applies it ONLY if
+  `lease_id` matches the task's authoritative lease (fencing), mapping
+  AWAITING→WAITING, SUBMITTED→SUBMITTED, FAILED→FAILED. A worker never asserts
+  DONE (INV-7). It is a structured receipt/event, not a free-text ledger.
 - **Event representation** and, specifically, **global monotonic sequence
   allocation** — DEFERRED. Events currently carry only a unique id and are
   audit-only. A global monotonic sequence + cursor bus is designed only when
@@ -227,6 +278,14 @@ ts       wall clock (audit only)
 ---
 
 ## 8. Minimal shadow V2 (read-only; proves the model before any control) [PROVISIONAL]
+
+Status note (v0.3): shadow was the planned way to de-risk the model before any
+control. In practice the model was validated directly by ISOLATED canaries — a
+dedicated tmux server + a separate session, live farm untouched — exercising real
+launch, crash-adoption, and resume (§10). Shadow (`farm shadow`) remains
+available and useful as a read-only differential tool against a running farm, but
+is no longer a prerequisite gate. The sections below are retained as the shadow
+contract for that tool.
 
 Goal: a READ-ONLY reconciler that derives task state from existing artifacts
 and LOGS what it WOULD do, compared event-by-event against the live nudger.
@@ -319,3 +378,65 @@ SLURM state, explicit `.awaiting` conditions, and artifact/ruling refs that
 already exist. Wake cases that depend on "did the worker read this master
 message" are expected to surface as observability-gaps, not forced coverage —
 that gap is itself the deliverable pointing to the canary receipt primitive.
+
+---
+
+## 10. Implementation status (v0.3) [maps contract → code]
+
+The minimal actuation layer is implemented and validated by real-codex canaries
+(isolated tmux server, live farm untouched). This section is the authoritative
+map from contract to code; it does not add new semantics.
+
+### 10.1 Invariant → realization
+| Invariant | Realized by |
+|---|---|
+| INV-1 durable authority | `store.TaskStore` (per-task JSON is the only authoritative read) |
+| INV-2 reconstructable orchestrators | reconciler + master hold no state; all state in `.farm/` |
+| INV-3 compute decoupled | runtime records `waiting_on: job:<id>`; never submits/cancels SLURM |
+| INV-4 state, not clock | control reads task state; only death-detection compares a heartbeat clock (a mechanism, §INV-10) |
+| INV-5 fencing lease | `transitions.validate_transition` rejects a stale `lease_id`; receipts fenced by `lease_id` |
+| INV-6 serialized reconcile | `locking.single_reconciler` (flock); `reconcile_once` is idempotent |
+| INV-7 one mutation path | `Reconciler._commit` (durable write + event) for BOTH transitions and lease acquire/rotate/release; DONE needs recorded acceptance |
+| INV-8 idempotent events | `events.EventLog` append-only, unique ids |
+| INV-9 persist-before-actuate | `_start` commits RUNNING+lease before `executor.launch`; commits new ownership before stopping the stale generation; launch idempotent per lease |
+| INV-10 durable death (grace) | `_durably_dead` (no heartbeat within `grace_seconds` + no receipt) gates `rotate_lease` |
+| INV-11 stable worker identity | `procutil` `(pid, starttime)` recorded at launch AND resume via one shared shell block; liveness never a workspace pgrep |
+| INV-12 one active task per workspace | `doctor` FAILs on two RUNNING/WAITING tasks sharing `metadata.workspace` |
+
+### 10.2 Ratified from v0.2 deferrals
+- **Lease rotation** (acquire/rotate/release) is now a first-class authoritative
+  mutation through `_commit` (was flagged in v0.2 as "beyond the frozen graph").
+  `rotate_lease` requires a `reason` establishing death and is guarded to never
+  rotate off a possibly-live holder.
+- **Structured receipt/ack primitive** (v0.2 §8/§9 "observability gap") is
+  implemented and fenced (§5, PINNED).
+- **INV-6 lock** is a real flock (v0.2 listed it as TBD).
+
+### 10.3 Executors & session handling
+- `adapters/base.WorkerExecutor` = `launch / resume / poll / stop`.
+- `adapters/local_process.LocalProcessExecutor` — real subprocesses; identity via
+  `(pid, starttime)`; reaps zombies.
+- `adapters/codex.CodexTmuxExecutor` — codex workers in a tmux session on a
+  DEDICATED tmux server (`-L <socket>`), a session separate from any live
+  `farm`; never kills/moves windows; pane identity = worker id; cluster
+  specifics in `CodexClusterConfig` (no personal paths in the module). The codex
+  session id is captured from the worker's OWN log (`session id: <uuid>`),
+  race-free; resume reuses it under the same lease.
+
+### 10.4 Canary evidence (real codex, isolated)
+- Launch happy-path: READY→…→SUBMITTED→DONE, doctor PASS, live farm untouched.
+- Crash-adoption: worker killed mid-run → `LEASE_ROTATED`+`WORKER_ADOPTED` (new
+  lease), task state survived; successor recovered from durable workspace state.
+- Resume identity: worker AWAITING→ends (pid dead) → resume refreshes the
+  `(pid,starttime)` identity to the live process → stays alive across grace, no
+  false adoption → SUBMITTED→DONE.
+
+### 10.5 Still deferred (unchanged from v0.2 unless noted)
+- WAITING-condition OBSERVERS (`job:`/`artifact:`/`task:`/`ruling:` auto-unblock)
+  — the reconciler resumes on an injected predicate; the observers that evaluate
+  those conditions are the next build item (post-merge).
+- Event-as-signal-bus + global monotonic sequence/cursors (V2.1).
+- `rev`/CAS (single-reconciler lock + fencing suffice).
+- `decision_owner` / durable multi-master routing.
+- Priority scheduling; SLURM submit/cancel; enforcement against non-cooperative
+  (receipt-less) workers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = []
 
+[project.optional-dependencies]
+dev = ["pytest>=7"]
+
 [project.scripts]
 farm = "agent_farm_runtime.cli:main"
 

--- a/src/agent_farm_runtime/adapters/base.py
+++ b/src/agent_farm_runtime/adapters/base.py
@@ -1,12 +1,60 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol
+
+from ..models import Lease, Receipt, Task
+
+
+@dataclass(frozen=True)
+class LaunchHandle:
+    """Opaque handle to a launched worker process/session.
+
+    session_handle is executor-specific (a pid, a tmux "session:window", a codex
+    rollout id). The reconciler treats it as opaque and only stores it on the
+    observed Worker record.
+    """
+
+    worker_id: str
+    session_handle: str
+
+
+@dataclass(frozen=True)
+class WorkerObservation:
+    """What the executor can observe about a worker it launched.
+
+    alive: is the underlying process/session still running?
+    receipt: the worker's latest structured receipt, if it has written one.
+    The reconciler fences the receipt against Task.lease itself; the executor is
+    only responsible for surfacing it.
+    """
+
+    worker_id: str
+    alive: bool
+    receipt: Receipt | None = None
 
 
 class WorkerExecutor(Protocol):
-    """Future boundary for disposable worker backends."""
+    """Boundary for disposable worker backends (codex/tmux, local process, fake).
 
-    def observe(self) -> dict: ...
+    Contract:
+    - launch(task, lease): start a NEW worker to execute `task` under `lease`.
+      The worker is told its worker_id, task_id, and lease_id, and is told where
+      to write its receipt; it must echo lease_id in every receipt (fencing).
+    - resume(task, worker_id, lease): re-wake an existing worker for the same
+      lease (idempotent; cheap no-op if already awake).
+    - poll(worker_id): observe liveness + latest receipt. Never mutates.
+    - stop(worker_id): best-effort terminate; used when fencing off a superseded
+      or failed worker. Must be safe to call on an already-dead worker.
+    """
+
+    def launch(self, task: Task, lease: Lease) -> LaunchHandle: ...
+
+    def resume(self, task: Task, worker_id: str, lease: Lease) -> None: ...
+
+    def poll(self, worker_id: str) -> WorkerObservation: ...
+
+    def stop(self, worker_id: str) -> None: ...
 
 
 class ComputeObserver(Protocol):

--- a/src/agent_farm_runtime/adapters/codex.py
+++ b/src/agent_farm_runtime/adapters/codex.py
@@ -168,10 +168,15 @@ class CodexTmuxExecutor:
         runtime_dir: Path,
         *,
         session: str = "farm2",
+        tmux_socket: str | None = None,
         run: Callable[[list[str]], subprocess.CompletedProcess] = _default_run,
         is_alive: Callable[[str], bool] = _default_is_alive,
     ):
         self.session = session
+        # A dedicated tmux SERVER (via -L <socket>) fully isolates canary/runtime
+        # windows from a live farm sharing the same host: a crash of one server
+        # cannot take down the other. None = default server (shared).
+        self.tmux_socket = tmux_socket
         self.run = run
         self.is_alive = is_alive
         self.state_dir = Path(runtime_dir) / "codex_workers"
@@ -198,18 +203,24 @@ class CodexTmuxExecutor:
 
     # -- tmux helpers (create-if-absent + send-keys only) --------------------
 
+    def _tmux(self, *args: str) -> list[str]:
+        base = ["tmux"]
+        if self.tmux_socket:
+            base += ["-L", self.tmux_socket]
+        return base + list(args)
+
     def _ensure_window(self, window: str, cwd: str) -> None:
-        has = self.run(["tmux", "has-session", "-t", self.session])
+        has = self.run(self._tmux("has-session", "-t", self.session))
         if has.returncode != 0:
-            self.run(["tmux", "new-session", "-d", "-s", self.session,
-                      "-n", window, "-c", cwd])
+            self.run(self._tmux("new-session", "-d", "-s", self.session,
+                                 "-n", window, "-c", cwd))
             return
-        listed = self.run(["tmux", "list-windows", "-t", self.session, "-F", "#{window_name}"])
+        listed = self.run(self._tmux("list-windows", "-t", self.session, "-F", "#{window_name}"))
         if window not in (listed.stdout or "").split():
-            self.run(["tmux", "new-window", "-t", self.session, "-n", window, "-c", cwd])
+            self.run(self._tmux("new-window", "-t", self.session, "-n", window, "-c", cwd))
 
     def _send(self, window: str, line: str) -> None:
-        self.run(["tmux", "send-keys", "-t", f"{self.session}:{window}", line, "Enter"])
+        self.run(self._tmux("send-keys", "-t", f"{self.session}:{window}", line, "Enter"))
 
     # -- WorkerExecutor protocol ---------------------------------------------
 
@@ -286,6 +297,6 @@ class CodexTmuxExecutor:
         st = self._load_state(worker_id)
         if st is None:
             return
-        # send Ctrl-C into the window, then a scoped pkill by cwd match is done
-        # by the caller's environment; here we C-c the interactive pane.
-        self.run(["tmux", "send-keys", "-t", f"{self.session}:{st['window']}", "C-c"])
+        # send Ctrl-C into the window to interrupt codex; leaves the window intact
+        # (no window surgery). A scoped pkill-by-cwd is left to the environment.
+        self.run(self._tmux("send-keys", "-t", f"{self.session}:{st['window']}", "C-c"))

--- a/src/agent_farm_runtime/adapters/codex.py
+++ b/src/agent_farm_runtime/adapters/codex.py
@@ -1,5 +1,291 @@
-class CodexAdapter:
-    """Placeholder boundary for starting/resuming disposable Codex workers.
+from __future__ import annotations
 
-    Deliberately non-operational in the shadow-first release.
+import json
+import shlex
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+from ..models import Lease, Receipt, Task
+from .base import LaunchHandle, WorkerObservation
+
+# --- the receipt protocol the codex agent must honor ------------------------
+
+RECEIPT_HELPER = '''\
+#!/usr/bin/env python3
+"""Write a fenced runtime receipt. Usage:
+  python .farm_receipt.py AWAITING --waiting-on job:12345 --note "..."
+  python .farm_receipt.py SUBMITTED --note "deliverable ready"
+  python .farm_receipt.py FAILED --note "why"
+The worker_id/task_id/lease_id are read from the environment the runtime set."""
+import argparse, json, os, sys
+from datetime import datetime, timezone
+
+ap = argparse.ArgumentParser()
+ap.add_argument("status", choices=["RUNNING", "AWAITING", "SUBMITTED", "FAILED"])
+ap.add_argument("--note", default="")
+ap.add_argument("--waiting-on", default=None)
+a = ap.parse_args()
+try:
+    path = os.environ["FARM_RECEIPT_PATH"]
+    receipt = {
+        "worker_id": os.environ["FARM_WORKER_ID"],
+        "task_id": os.environ["FARM_TASK_ID"],
+        "lease_id": os.environ["FARM_LEASE_ID"],  # echo verbatim: fencing
+        "status": a.status,
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "note": a.note,
+        "waiting_on": a.waiting_on,
+    }
+except KeyError as e:
+    sys.exit(f"runtime env missing: {e}")
+with open(path, "w") as fh:
+    json.dump(receipt, fh)
+print(f"receipt {a.status} -> {path}")
+'''
+
+
+def receipt_instruction(receipt_path: str) -> str:
+    return (
+        "RUNTIME RECEIPT PROTOCOL (mandatory). You run under the durable farm "
+        "runtime; env vars FARM_RECEIPT_PATH, FARM_WORKER_ID, FARM_TASK_ID, "
+        "FARM_LEASE_ID are set. Before you END any run you MUST record a receipt "
+        "by calling `python .farm_receipt.py <STATUS> [--waiting-on ...] [--note ...]` "
+        "in your workspace: AWAITING when you stop to wait on a job/file/ruling "
+        "(pass --waiting-on job:ID | artifact:/abs/path | task:ID | ruling:NAME), "
+        "SUBMITTED when the deliverable is ready for the master's acceptance, "
+        "FAILED on an unrecoverable error. The helper echoes FARM_LEASE_ID for "
+        "you (fencing). Never claim DONE — acceptance is the master's decision. "
+        f"Your receipt path is {receipt_path}."
+    )
+
+
+# --- script rendering (pure; unit-tested) -----------------------------------
+
+_PATH_LINE = "export PATH=/n/home06/tjiang/.nvm/versions/node/v22.17.1/bin:$PATH"
+_CODEX = "codex exec --skip-git-repo-check --sandbox danger-full-access"
+
+
+def _env_exports(workspace: str, worker_id: str, task_id: str, lease_id: str, receipt_path: str) -> str:
+    return "\n".join(
+        f"export {k}={shlex.quote(v)}"
+        for k, v in {
+            "FARM_WORKER_ID": worker_id,
+            "FARM_TASK_ID": task_id,
+            "FARM_LEASE_ID": lease_id,
+            "FARM_RECEIPT_PATH": receipt_path,
+        }.items()
+    )
+
+
+def render_launch_script(
+    *, workspace: str, worker_id: str, task_id: str, lease_id: str,
+    receipt_path: str, brief: str, log_name: str, sid_path: str,
+) -> str:
+    """A headless-codex launch script mirroring the proven RESTART_HEADLESS.sh,
+    plus runtime env + the receipt protocol. Captures the codex session id (for
+    later resume) via the same post-start rollout scrape the live farm uses."""
+    full_brief = brief.rstrip() + "\n\n" + receipt_instruction(receipt_path)
+    sess_dir = "/n/home06/tjiang/.codex/sessions/$(date +%Y/%m/%d)"
+    return f"""#!/bin/bash
+cd {shlex.quote(workspace)}
+{_PATH_LINE}
+{_env_exports(workspace, worker_id, task_id, lease_id, receipt_path)}
+rm -f {shlex.quote(receipt_path)}
+# capture the new codex session id shortly after start (for resume)
+( sleep 45; f=$(ls -t {sess_dir}/rollout-*.jsonl 2>/dev/null | head -1); \
+  [ -n "$f" ] && echo "$f" | grep -oE '[0-9a-f-]{{36}}' > {shlex.quote(sid_path)} ) &
+{_CODEX} {shlex.quote(full_brief)} 2>&1 | tee {shlex.quote(log_name)}
+"""
+
+
+def render_resume_script(
+    *, workspace: str, worker_id: str, task_id: str, lease_id: str,
+    receipt_path: str, sid_path: str, log_name: str, wake_msg: str,
+) -> str:
+    """Resume an existing codex session (mirrors WAKE.sh) under the same lease."""
+    full_msg = wake_msg.rstrip() + "\n\n" + receipt_instruction(receipt_path)
+    return f"""#!/bin/bash
+cd {shlex.quote(workspace)}
+{_PATH_LINE}
+{_env_exports(workspace, worker_id, task_id, lease_id, receipt_path)}
+rm -f {shlex.quote(receipt_path)}
+SID=$(cat {shlex.quote(sid_path)} 2>/dev/null)
+if [ -z "$SID" ]; then echo "no session id at {sid_path}; cannot resume" >&2; exit 3; fi
+{_CODEX} resume "$SID" {shlex.quote(full_msg)} 2>&1 | tee -a {shlex.quote(log_name)}
+"""
+
+
+# --- the executor -----------------------------------------------------------
+
+def _default_run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def _default_is_alive(workspace: str) -> bool:
+    """Live iff a codex process has this workspace as cwd (the farm's own test)."""
+    try:
+        pids = subprocess.run(["pgrep", "-u", str(_uid()), "-x", "codex"],
+                              capture_output=True, text=True).stdout.split()
+    except FileNotFoundError:
+        return False
+    target = str(Path(workspace).resolve())
+    for pid in pids:
+        try:
+            if str(Path(f"/proc/{pid}/cwd").resolve()) == target:
+                return True
+        except (OSError, RuntimeError):
+            continue
+    return False
+
+
+def _uid() -> int:
+    import os
+    return os.getuid()
+
+
+class CodexTmuxExecutor:
+    """Real farm backend: disposable codex workers in a tmux session.
+
+    Faithful translation of the live farm's launch (RESTART_HEADLESS.sh) and
+    wake (WAKE.sh), wrapped in the runtime's lease/receipt contract.
+
+    Safety (given the prior tmux-server crash from live window surgery):
+      * targets a CONFIGURABLE session, defaulting to one SEPARATE from the live
+        `farm` session, so canary runs never touch production;
+      * NEVER kills or moves tmux windows -- only creates a window if absent and
+        sends keys into it; `stop` terminates the codex process, not the window;
+      * all tmux/pgrep calls go through injectable callables, so the class is
+        unit-tested without a real tmux server or codex.
+
+    Task metadata contract: metadata["workspace"] (abs dir, required),
+    metadata["brief"] (agent-facing English brief, required),
+    metadata["agent_label"] (tmux window name; defaults to a per-worker name).
     """
+
+    def __init__(
+        self,
+        runtime_dir: Path,
+        *,
+        session: str = "farm2",
+        run: Callable[[list[str]], subprocess.CompletedProcess] = _default_run,
+        is_alive: Callable[[str], bool] = _default_is_alive,
+    ):
+        self.session = session
+        self.run = run
+        self.is_alive = is_alive
+        self.state_dir = Path(runtime_dir) / "codex_workers"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.receipts_dir = Path(runtime_dir) / "receipts"
+        self.receipts_dir.mkdir(parents=True, exist_ok=True)
+
+    # -- per-worker persisted mapping (worker_id -> workspace/paths) ----------
+
+    def _state_path(self, worker_id: str) -> Path:
+        return self.state_dir / f"{worker_id}.json"
+
+    def _save_state(self, worker_id: str, data: dict) -> None:
+        self._state_path(worker_id).write_text(json.dumps(data, indent=2))
+
+    def _load_state(self, worker_id: str) -> dict | None:
+        p = self._state_path(worker_id)
+        if not p.exists():
+            return None
+        return json.loads(p.read_text())
+
+    def _receipt_path(self, worker_id: str) -> Path:
+        return self.receipts_dir / f"{worker_id}.json"
+
+    # -- tmux helpers (create-if-absent + send-keys only) --------------------
+
+    def _ensure_window(self, window: str, cwd: str) -> None:
+        has = self.run(["tmux", "has-session", "-t", self.session])
+        if has.returncode != 0:
+            self.run(["tmux", "new-session", "-d", "-s", self.session,
+                      "-n", window, "-c", cwd])
+            return
+        listed = self.run(["tmux", "list-windows", "-t", self.session, "-F", "#{window_name}"])
+        if window not in (listed.stdout or "").split():
+            self.run(["tmux", "new-window", "-t", self.session, "-n", window, "-c", cwd])
+
+    def _send(self, window: str, line: str) -> None:
+        self.run(["tmux", "send-keys", "-t", f"{self.session}:{window}", line, "Enter"])
+
+    # -- WorkerExecutor protocol ---------------------------------------------
+
+    def launch(self, task: Task, lease: Lease) -> LaunchHandle:
+        ws = task.metadata.get("workspace")
+        brief = task.metadata.get("brief")
+        if not ws or not brief:
+            raise ValueError(f"task {task.id} needs metadata.workspace and metadata.brief")
+        wid = lease.worker_id
+        window = task.metadata.get("agent_label") or wid
+        workspace = str(Path(ws).resolve())
+        receipt_path = str(self._receipt_path(wid))
+        sid_path = str(Path(workspace) / f".session_id_{wid}")
+        log_name = f"agent_{window}_{wid}.log"
+        launch_sh = Path(workspace) / f".farm_launch_{wid}.sh"
+
+        # drop the receipt helper + launch script into the workspace
+        (Path(workspace) / ".farm_receipt.py").write_text(RECEIPT_HELPER)
+        launch_sh.write_text(render_launch_script(
+            workspace=workspace, worker_id=wid, task_id=task.id,
+            lease_id=lease.lease_id, receipt_path=receipt_path, brief=brief,
+            log_name=log_name, sid_path=sid_path,
+        ))
+        launch_sh.chmod(0o755)
+
+        self._save_state(wid, {
+            "workspace": workspace, "window": window, "receipt_path": receipt_path,
+            "sid_path": sid_path, "log_name": log_name, "task_id": task.id,
+            "lease_id": lease.lease_id,
+        })
+        self._ensure_window(window, workspace)
+        self._send(window, f"bash {shlex.quote(str(launch_sh))}")
+        return LaunchHandle(worker_id=wid, session_handle=f"{self.session}:{window}")
+
+    def resume(self, task: Task, worker_id: str, lease: Lease) -> None:
+        st = self._load_state(worker_id)
+        if st is None:
+            # no prior generation to resume; fall back to a fresh launch
+            self.launch(task, lease)
+            return
+        resume_sh = Path(st["workspace"]) / f".farm_resume_{worker_id}.sh"
+        resume_sh.write_text(render_resume_script(
+            workspace=st["workspace"], worker_id=worker_id, task_id=task.id,
+            lease_id=lease.lease_id, receipt_path=st["receipt_path"],
+            sid_path=st["sid_path"], log_name=st["log_name"],
+            wake_msg=("Wake-up: a condition you were awaiting has fired or a new "
+                      "MASTER_*.md landed. Re-scan your workspace, verify the awaited "
+                      "state, acknowledge in LEDGER, and continue."),
+        ))
+        resume_sh.chmod(0o755)
+        self._ensure_window(st["window"], st["workspace"])
+        self._send(st["window"], f"bash {shlex.quote(str(resume_sh))}")
+
+    def poll(self, worker_id: str) -> WorkerObservation:
+        st = self._load_state(worker_id)
+        if st is None:
+            return WorkerObservation(worker_id=worker_id, alive=False, receipt=None)
+        receipt = None
+        rp = Path(st["receipt_path"])
+        if rp.exists():
+            try:
+                receipt = Receipt.from_dict(json.loads(rp.read_text()))
+            except (ValueError, KeyError):
+                receipt = None
+        return WorkerObservation(
+            worker_id=worker_id,
+            alive=self.is_alive(st["workspace"]),
+            receipt=receipt,
+        )
+
+    def stop(self, worker_id: str) -> None:
+        """Terminate the codex process for this worker's workspace. Leaves the
+        tmux window intact (no window surgery)."""
+        st = self._load_state(worker_id)
+        if st is None:
+            return
+        # send Ctrl-C into the window, then a scoped pkill by cwd match is done
+        # by the caller's environment; here we C-c the interactive pane.
+        self.run(["tmux", "send-keys", "-t", f"{self.session}:{st['window']}", "C-c"])

--- a/src/agent_farm_runtime/adapters/codex.py
+++ b/src/agent_farm_runtime/adapters/codex.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..models import Lease, Receipt, Task
+from ..procutil import pid_identity_alive, read_pidfile
 from .base import LaunchHandle, WorkerObservation
 
 # --- the receipt protocol the codex agent must honor ------------------------
@@ -77,8 +78,6 @@ class CodexClusterConfig:
     # shell line(s) to prepare PATH inside the tmux window (e.g. an nvm export);
     # empty means "codex is already on the login shell PATH".
     path_prelude: str = ""
-    # directory (a shell expression is allowed) where codex writes rollout-*.jsonl
-    sessions_dir: str = "$HOME/.codex/sessions/$(date +%Y/%m/%d)"
     session_id_capture_delay: int = 45
 
     @classmethod
@@ -87,7 +86,6 @@ class CodexClusterConfig:
         return cls(
             codex_cmd=os.environ.get("FARM_CODEX_CMD", d.codex_cmd),
             path_prelude=os.environ.get("FARM_CODEX_PATH_PRELUDE", d.path_prelude),
-            sessions_dir=os.environ.get("FARM_CODEX_SESSIONS_DIR", d.sessions_dir),
             session_id_capture_delay=int(
                 os.environ.get("FARM_CODEX_SID_DELAY", d.session_id_capture_delay)
             ),
@@ -115,25 +113,35 @@ def _prelude(cfg: CodexClusterConfig) -> str:
 def render_launch_script(
     *, cfg: CodexClusterConfig, workspace: str, worker_id: str, task_id: str,
     lease_id: str, receipt_path: str, brief: str, log_name: str, sid_path: str,
+    pid_file: str,
 ) -> str:
     """Headless-codex launch mirroring the proven RESTART_HEADLESS.sh, plus the
-    runtime env + receipt protocol. Session-id capture diffs the rollout set
-    against a pre-launch snapshot (rather than blindly taking the newest file),
-    which is robust to pre-existing rollouts; concurrent starts within the
-    capture window remain ambiguous and are serialized by the reconciler."""
+    runtime env + receipt protocol.
+
+    Worker identity: codex is started in the background so its exact pid is known;
+    the pid and its /proc start-time are written to `pid_file` as a stable
+    (pid,starttime) identity (liveness is per-worker, never a workspace-wide
+    pgrep). Session-id capture greps the session id codex prints at startup into
+    THIS worker's own (per-worker) log -- race-free even when several codex
+    workers start concurrently, and with no dependence on the shared sessions dir.
+    """
     full_brief = brief.rstrip() + "\n\n" + receipt_instruction(receipt_path)
-    sd = cfg.sessions_dir
+    delay = cfg.session_id_capture_delay
     return f"""#!/bin/bash
 cd {shlex.quote(workspace)}
 {_prelude(cfg)}{_env_exports(worker_id, task_id, lease_id, receipt_path)}
 rm -f {shlex.quote(receipt_path)}
-# capture the NEW codex session id (rollout that appears after launch)
-_PRE=$(mktemp); ls -1 {sd}/rollout-*.jsonl 2>/dev/null > "$_PRE" || true
-( sleep {cfg.session_id_capture_delay}; \
-  f=$(ls -t {sd}/rollout-*.jsonl 2>/dev/null | grep -vxF -f "$_PRE" | head -1); \
-  [ -n "$f" ] && echo "$f" | grep -oE '[0-9a-f-]{{36}}' > {shlex.quote(sid_path)}; \
-  rm -f "$_PRE" ) &
-{cfg.codex_cmd} {shlex.quote(full_brief)} 2>&1 | tee {shlex.quote(log_name)}
+{cfg.codex_cmd} {shlex.quote(full_brief)} > >(tee {shlex.quote(log_name)}) 2>&1 &
+_CPID=$!
+_ST=$(awk '{{s=substr($0,index($0,") ")+2); n=split(s,a," "); print a[20]}}' /proc/$_CPID/stat 2>/dev/null)
+echo "$_CPID $_ST" > {shlex.quote(pid_file)}
+# race-free session id: codex prints it into THIS worker's own log at startup
+( for _ in $(seq 1 {delay}); do
+    sid=$(grep -oiE 'session id: [0-9a-f-]{{36}}' {shlex.quote(log_name)} 2>/dev/null | grep -oE '[0-9a-f-]{{36}}' | head -1)
+    [ -n "$sid" ] && {{ echo "$sid" > {shlex.quote(sid_path)}; break; }}
+    sleep 1
+  done ) &
+wait $_CPID
 """
 
 
@@ -155,24 +163,20 @@ if [ -z "$SID" ]; then echo "no session id at {sid_path}; cannot resume" >&2; ex
 
 # --- liveness (default; injectable) -----------------------------------------
 
-def _default_is_alive(workspace: str) -> bool:
-    """Live iff a codex process has this workspace as cwd (the farm's own test).
+def _default_codex_alive(state: dict) -> bool:
+    """Per-worker liveness: is the SPECIFIC codex process we launched still the
+    live process at its recorded (pid, starttime)?
 
-    NOTE: this is a best-effort signal; the reconciler's grace policy — not this
-    function — is what protects a live worker from a transient miss."""
-    try:
-        pids = subprocess.run(["pgrep", "-u", str(os.getuid()), "-x", "codex"],
-                              capture_output=True, text=True).stdout.split()
-    except FileNotFoundError:
+    This deliberately does NOT scan for any codex whose cwd matches the workspace:
+    a workspace-level pgrep cannot tell two workers (e.g. a dead prior generation
+    and its live successor) apart in the same workspace. Identity is the launched
+    pid plus its /proc start-time, so a recycled pid is not mistaken for a worker.
+    """
+    pid_file = state.get("pid_file")
+    if not pid_file:
         return False
-    target = str(Path(workspace).resolve())
-    for pid in pids:
-        try:
-            if str(Path(f"/proc/{pid}/cwd").resolve()) == target:
-                return True
-        except (OSError, RuntimeError):
-            continue
-    return False
+    pid, start = read_pidfile(pid_file)
+    return pid_identity_alive(pid, start)
 
 
 def _default_run(cmd: list[str]) -> subprocess.CompletedProcess:
@@ -209,7 +213,7 @@ class CodexTmuxExecutor:
         tmux_socket: str | None = None,
         config: CodexClusterConfig | None = None,
         run: Callable[[list[str]], subprocess.CompletedProcess] = _default_run,
-        is_alive: Callable[[str], bool] = _default_is_alive,
+        is_alive: Callable[[dict], bool] = _default_codex_alive,
     ):
         self.session = session
         self.tmux_socket = tmux_socket
@@ -266,12 +270,14 @@ class CodexTmuxExecutor:
         window = task.metadata.get("agent_label") or wid
         workspace = str(Path(ws).resolve())
 
-        # idempotent per lease: never start a second codex for a live worker
+        # idempotent per lease: never start a second codex for THIS live worker
+        # (judged by this worker's own pid identity, not any codex in the workspace)
         st = self._load_state(wid)
-        if st is not None and self.is_alive(workspace):
+        if st is not None and self.is_alive(st):
             return LaunchHandle(worker_id=wid, session_handle=f"{self.session}:{window}")
 
         receipt_path = str(self._receipt_path(wid))
+        pid_file = str(self.state_dir / f"{wid}.pid")
         sid_path = str(Path(workspace) / f".session_id_{wid}")
         log_name = f"agent_{window}_{wid}.log"
         launch_sh = Path(workspace) / f".farm_launch_{wid}.sh"
@@ -280,13 +286,13 @@ class CodexTmuxExecutor:
         launch_sh.write_text(render_launch_script(
             cfg=self.config, workspace=workspace, worker_id=wid, task_id=task.id,
             lease_id=lease.lease_id, receipt_path=receipt_path, brief=brief,
-            log_name=log_name, sid_path=sid_path,
+            log_name=log_name, sid_path=sid_path, pid_file=pid_file,
         ))
         launch_sh.chmod(0o755)
         self._save_state(wid, {
             "workspace": workspace, "window": window, "receipt_path": receipt_path,
             "sid_path": sid_path, "log_name": log_name, "task_id": task.id,
-            "lease_id": lease.lease_id,
+            "lease_id": lease.lease_id, "pid_file": pid_file,
         })
         self._ensure_window(window, workspace)
         self._send(window, f"bash {shlex.quote(str(launch_sh))}")
@@ -321,7 +327,7 @@ class CodexTmuxExecutor:
                 receipt = Receipt.from_dict(json.loads(rp.read_text()))
             except (ValueError, KeyError):
                 receipt = None
-        return WorkerObservation(worker_id=worker_id, alive=self.is_alive(st["workspace"]), receipt=receipt)
+        return WorkerObservation(worker_id=worker_id, alive=self.is_alive(st), receipt=receipt)
 
     def stop(self, worker_id: str) -> None:
         """Interrupt codex in the worker's window; leaves the window intact."""

--- a/src/agent_farm_runtime/adapters/codex.py
+++ b/src/agent_farm_runtime/adapters/codex.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from ..models import Lease, Receipt, Task
@@ -60,13 +62,41 @@ def receipt_instruction(receipt_path: str) -> str:
     )
 
 
+# --- cluster configuration (no cluster/user specifics baked into the adapter) -
+
+@dataclass(frozen=True)
+class CodexClusterConfig:
+    """Cluster/user-specific knobs pushed OUT of the generic adapter.
+
+    Defaults are generic ($HOME-based, codex assumed on PATH). A site supplies
+    its specifics via `from_env()` (FARM_CODEX_* vars) or an explicit instance,
+    so the module contains no hard-coded personal paths.
+    """
+
+    codex_cmd: str = "codex exec --skip-git-repo-check --sandbox danger-full-access"
+    # shell line(s) to prepare PATH inside the tmux window (e.g. an nvm export);
+    # empty means "codex is already on the login shell PATH".
+    path_prelude: str = ""
+    # directory (a shell expression is allowed) where codex writes rollout-*.jsonl
+    sessions_dir: str = "$HOME/.codex/sessions/$(date +%Y/%m/%d)"
+    session_id_capture_delay: int = 45
+
+    @classmethod
+    def from_env(cls) -> "CodexClusterConfig":
+        d = cls()
+        return cls(
+            codex_cmd=os.environ.get("FARM_CODEX_CMD", d.codex_cmd),
+            path_prelude=os.environ.get("FARM_CODEX_PATH_PRELUDE", d.path_prelude),
+            sessions_dir=os.environ.get("FARM_CODEX_SESSIONS_DIR", d.sessions_dir),
+            session_id_capture_delay=int(
+                os.environ.get("FARM_CODEX_SID_DELAY", d.session_id_capture_delay)
+            ),
+        )
+
+
 # --- script rendering (pure; unit-tested) -----------------------------------
 
-_PATH_LINE = "export PATH=/n/home06/tjiang/.nvm/versions/node/v22.17.1/bin:$PATH"
-_CODEX = "codex exec --skip-git-repo-check --sandbox danger-full-access"
-
-
-def _env_exports(workspace: str, worker_id: str, task_id: str, lease_id: str, receipt_path: str) -> str:
+def _env_exports(worker_id: str, task_id: str, lease_id: str, receipt_path: str) -> str:
     return "\n".join(
         f"export {k}={shlex.quote(v)}"
         for k, v in {
@@ -78,54 +108,60 @@ def _env_exports(workspace: str, worker_id: str, task_id: str, lease_id: str, re
     )
 
 
+def _prelude(cfg: CodexClusterConfig) -> str:
+    return (cfg.path_prelude + "\n") if cfg.path_prelude else ""
+
+
 def render_launch_script(
-    *, workspace: str, worker_id: str, task_id: str, lease_id: str,
-    receipt_path: str, brief: str, log_name: str, sid_path: str,
+    *, cfg: CodexClusterConfig, workspace: str, worker_id: str, task_id: str,
+    lease_id: str, receipt_path: str, brief: str, log_name: str, sid_path: str,
 ) -> str:
-    """A headless-codex launch script mirroring the proven RESTART_HEADLESS.sh,
-    plus runtime env + the receipt protocol. Captures the codex session id (for
-    later resume) via the same post-start rollout scrape the live farm uses."""
+    """Headless-codex launch mirroring the proven RESTART_HEADLESS.sh, plus the
+    runtime env + receipt protocol. Session-id capture diffs the rollout set
+    against a pre-launch snapshot (rather than blindly taking the newest file),
+    which is robust to pre-existing rollouts; concurrent starts within the
+    capture window remain ambiguous and are serialized by the reconciler."""
     full_brief = brief.rstrip() + "\n\n" + receipt_instruction(receipt_path)
-    sess_dir = "/n/home06/tjiang/.codex/sessions/$(date +%Y/%m/%d)"
+    sd = cfg.sessions_dir
     return f"""#!/bin/bash
 cd {shlex.quote(workspace)}
-{_PATH_LINE}
-{_env_exports(workspace, worker_id, task_id, lease_id, receipt_path)}
+{_prelude(cfg)}{_env_exports(worker_id, task_id, lease_id, receipt_path)}
 rm -f {shlex.quote(receipt_path)}
-# capture the new codex session id shortly after start (for resume)
-( sleep 45; f=$(ls -t {sess_dir}/rollout-*.jsonl 2>/dev/null | head -1); \
-  [ -n "$f" ] && echo "$f" | grep -oE '[0-9a-f-]{{36}}' > {shlex.quote(sid_path)} ) &
-{_CODEX} {shlex.quote(full_brief)} 2>&1 | tee {shlex.quote(log_name)}
+# capture the NEW codex session id (rollout that appears after launch)
+_PRE=$(mktemp); ls -1 {sd}/rollout-*.jsonl 2>/dev/null > "$_PRE" || true
+( sleep {cfg.session_id_capture_delay}; \
+  f=$(ls -t {sd}/rollout-*.jsonl 2>/dev/null | grep -vxF -f "$_PRE" | head -1); \
+  [ -n "$f" ] && echo "$f" | grep -oE '[0-9a-f-]{{36}}' > {shlex.quote(sid_path)}; \
+  rm -f "$_PRE" ) &
+{cfg.codex_cmd} {shlex.quote(full_brief)} 2>&1 | tee {shlex.quote(log_name)}
 """
 
 
 def render_resume_script(
-    *, workspace: str, worker_id: str, task_id: str, lease_id: str,
-    receipt_path: str, sid_path: str, log_name: str, wake_msg: str,
+    *, cfg: CodexClusterConfig, workspace: str, worker_id: str, task_id: str,
+    lease_id: str, receipt_path: str, sid_path: str, log_name: str, wake_msg: str,
 ) -> str:
     """Resume an existing codex session (mirrors WAKE.sh) under the same lease."""
     full_msg = wake_msg.rstrip() + "\n\n" + receipt_instruction(receipt_path)
     return f"""#!/bin/bash
 cd {shlex.quote(workspace)}
-{_PATH_LINE}
-{_env_exports(workspace, worker_id, task_id, lease_id, receipt_path)}
+{_prelude(cfg)}{_env_exports(worker_id, task_id, lease_id, receipt_path)}
 rm -f {shlex.quote(receipt_path)}
 SID=$(cat {shlex.quote(sid_path)} 2>/dev/null)
 if [ -z "$SID" ]; then echo "no session id at {sid_path}; cannot resume" >&2; exit 3; fi
-{_CODEX} resume "$SID" {shlex.quote(full_msg)} 2>&1 | tee -a {shlex.quote(log_name)}
+{cfg.codex_cmd} resume "$SID" {shlex.quote(full_msg)} 2>&1 | tee -a {shlex.quote(log_name)}
 """
 
 
-# --- the executor -----------------------------------------------------------
-
-def _default_run(cmd: list[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(cmd, capture_output=True, text=True)
-
+# --- liveness (default; injectable) -----------------------------------------
 
 def _default_is_alive(workspace: str) -> bool:
-    """Live iff a codex process has this workspace as cwd (the farm's own test)."""
+    """Live iff a codex process has this workspace as cwd (the farm's own test).
+
+    NOTE: this is a best-effort signal; the reconciler's grace policy — not this
+    function — is what protects a live worker from a transient miss."""
     try:
-        pids = subprocess.run(["pgrep", "-u", str(_uid()), "-x", "codex"],
+        pids = subprocess.run(["pgrep", "-u", str(os.getuid()), "-x", "codex"],
                               capture_output=True, text=True).stdout.split()
     except FileNotFoundError:
         return False
@@ -139,9 +175,8 @@ def _default_is_alive(workspace: str) -> bool:
     return False
 
 
-def _uid() -> int:
-    import os
-    return os.getuid()
+def _default_run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True)
 
 
 class CodexTmuxExecutor:
@@ -150,17 +185,20 @@ class CodexTmuxExecutor:
     Faithful translation of the live farm's launch (RESTART_HEADLESS.sh) and
     wake (WAKE.sh), wrapped in the runtime's lease/receipt contract.
 
-    Safety (given the prior tmux-server crash from live window surgery):
-      * targets a CONFIGURABLE session, defaulting to one SEPARATE from the live
-        `farm` session, so canary runs never touch production;
-      * NEVER kills or moves tmux windows -- only creates a window if absent and
-        sends keys into it; `stop` terminates the codex process, not the window;
-      * all tmux/pgrep calls go through injectable callables, so the class is
-        unit-tested without a real tmux server or codex.
+    Safety (given a prior tmux-server crash from live window surgery):
+      * a dedicated tmux SERVER (`-L <socket>`) fully isolates these windows from
+        a live farm on the same host;
+      * targets a configurable SESSION, defaulting to one separate from `farm`;
+      * NEVER kills or moves windows — only create-if-absent + send-keys; `stop`
+        only C-c's the pane;
+      * launch is IDEMPOTENT per lease/worker (won't start a second codex if the
+        worker is already alive);
+      * cluster/user specifics live in CodexClusterConfig, not in this module;
+      * all tmux/pgrep calls are injectable -> unit-tested without real tmux/codex.
 
-    Task metadata contract: metadata["workspace"] (abs dir, required),
-    metadata["brief"] (agent-facing English brief, required),
-    metadata["agent_label"] (tmux window name; defaults to a per-worker name).
+    Task metadata: metadata["workspace"] (abs dir, required), metadata["brief"]
+    (agent brief, required), metadata["agent_label"] (tmux window; default
+    per-worker).
     """
 
     def __init__(
@@ -169,14 +207,13 @@ class CodexTmuxExecutor:
         *,
         session: str = "farm2",
         tmux_socket: str | None = None,
+        config: CodexClusterConfig | None = None,
         run: Callable[[list[str]], subprocess.CompletedProcess] = _default_run,
         is_alive: Callable[[str], bool] = _default_is_alive,
     ):
         self.session = session
-        # A dedicated tmux SERVER (via -L <socket>) fully isolates canary/runtime
-        # windows from a live farm sharing the same host: a crash of one server
-        # cannot take down the other. None = default server (shared).
         self.tmux_socket = tmux_socket
+        self.config = config or CodexClusterConfig.from_env()
         self.run = run
         self.is_alive = is_alive
         self.state_dir = Path(runtime_dir) / "codex_workers"
@@ -184,7 +221,7 @@ class CodexTmuxExecutor:
         self.receipts_dir = Path(runtime_dir) / "receipts"
         self.receipts_dir.mkdir(parents=True, exist_ok=True)
 
-    # -- per-worker persisted mapping (worker_id -> workspace/paths) ----------
+    # -- per-worker persisted mapping -----------------------------------------
 
     def _state_path(self, worker_id: str) -> Path:
         return self.state_dir / f"{worker_id}.json"
@@ -194,9 +231,7 @@ class CodexTmuxExecutor:
 
     def _load_state(self, worker_id: str) -> dict | None:
         p = self._state_path(worker_id)
-        if not p.exists():
-            return None
-        return json.loads(p.read_text())
+        return json.loads(p.read_text()) if p.exists() else None
 
     def _receipt_path(self, worker_id: str) -> Path:
         return self.receipts_dir / f"{worker_id}.json"
@@ -210,10 +245,8 @@ class CodexTmuxExecutor:
         return base + list(args)
 
     def _ensure_window(self, window: str, cwd: str) -> None:
-        has = self.run(self._tmux("has-session", "-t", self.session))
-        if has.returncode != 0:
-            self.run(self._tmux("new-session", "-d", "-s", self.session,
-                                 "-n", window, "-c", cwd))
+        if self.run(self._tmux("has-session", "-t", self.session)).returncode != 0:
+            self.run(self._tmux("new-session", "-d", "-s", self.session, "-n", window, "-c", cwd))
             return
         listed = self.run(self._tmux("list-windows", "-t", self.session, "-F", "#{window_name}"))
         if window not in (listed.stdout or "").split():
@@ -232,20 +265,24 @@ class CodexTmuxExecutor:
         wid = lease.worker_id
         window = task.metadata.get("agent_label") or wid
         workspace = str(Path(ws).resolve())
+
+        # idempotent per lease: never start a second codex for a live worker
+        st = self._load_state(wid)
+        if st is not None and self.is_alive(workspace):
+            return LaunchHandle(worker_id=wid, session_handle=f"{self.session}:{window}")
+
         receipt_path = str(self._receipt_path(wid))
         sid_path = str(Path(workspace) / f".session_id_{wid}")
         log_name = f"agent_{window}_{wid}.log"
         launch_sh = Path(workspace) / f".farm_launch_{wid}.sh"
 
-        # drop the receipt helper + launch script into the workspace
         (Path(workspace) / ".farm_receipt.py").write_text(RECEIPT_HELPER)
         launch_sh.write_text(render_launch_script(
-            workspace=workspace, worker_id=wid, task_id=task.id,
+            cfg=self.config, workspace=workspace, worker_id=wid, task_id=task.id,
             lease_id=lease.lease_id, receipt_path=receipt_path, brief=brief,
             log_name=log_name, sid_path=sid_path,
         ))
         launch_sh.chmod(0o755)
-
         self._save_state(wid, {
             "workspace": workspace, "window": window, "receipt_path": receipt_path,
             "sid_path": sid_path, "log_name": log_name, "task_id": task.id,
@@ -258,12 +295,11 @@ class CodexTmuxExecutor:
     def resume(self, task: Task, worker_id: str, lease: Lease) -> None:
         st = self._load_state(worker_id)
         if st is None:
-            # no prior generation to resume; fall back to a fresh launch
-            self.launch(task, lease)
+            self.launch(task, lease)  # nothing to resume; fresh launch
             return
         resume_sh = Path(st["workspace"]) / f".farm_resume_{worker_id}.sh"
         resume_sh.write_text(render_resume_script(
-            workspace=st["workspace"], worker_id=worker_id, task_id=task.id,
+            cfg=self.config, workspace=st["workspace"], worker_id=worker_id, task_id=task.id,
             lease_id=lease.lease_id, receipt_path=st["receipt_path"],
             sid_path=st["sid_path"], log_name=st["log_name"],
             wake_msg=("Wake-up: a condition you were awaiting has fired or a new "
@@ -285,18 +321,11 @@ class CodexTmuxExecutor:
                 receipt = Receipt.from_dict(json.loads(rp.read_text()))
             except (ValueError, KeyError):
                 receipt = None
-        return WorkerObservation(
-            worker_id=worker_id,
-            alive=self.is_alive(st["workspace"]),
-            receipt=receipt,
-        )
+        return WorkerObservation(worker_id=worker_id, alive=self.is_alive(st["workspace"]), receipt=receipt)
 
     def stop(self, worker_id: str) -> None:
-        """Terminate the codex process for this worker's workspace. Leaves the
-        tmux window intact (no window surgery)."""
+        """Interrupt codex in the worker's window; leaves the window intact."""
         st = self._load_state(worker_id)
         if st is None:
             return
-        # send Ctrl-C into the window to interrupt codex; leaves the window intact
-        # (no window surgery). A scoped pkill-by-cwd is left to the environment.
         self.run(self._tmux("send-keys", "-t", f"{self.session}:{st['window']}", "C-c"))

--- a/src/agent_farm_runtime/adapters/codex.py
+++ b/src/agent_farm_runtime/adapters/codex.py
@@ -42,8 +42,13 @@ try:
     }
 except KeyError as e:
     sys.exit(f"runtime env missing: {e}")
-with open(path, "w") as fh:
+# atomic write: the reconciler must never read a half-written receipt
+tmp = f"{path}.tmp.{os.getpid()}"
+with open(tmp, "w") as fh:
     json.dump(receipt, fh)
+    fh.flush()
+    os.fsync(fh.fileno())
+os.replace(tmp, path)
 print(f"receipt {a.status} -> {path}")
 '''
 
@@ -110,55 +115,80 @@ def _prelude(cfg: CodexClusterConfig) -> str:
     return (cfg.path_prelude + "\n") if cfg.path_prelude else ""
 
 
+def _run_and_record(
+    *, invocation: str, log_name: str, pid_file: str, sid_path: str | None,
+    append_log: bool, delay: int,
+) -> str:
+    """Shared tail used by BOTH launch and resume: background the codex
+    invocation, record THIS invocation's (pid, starttime) identity to `pid_file`,
+    optionally capture the session id from this worker's own log, then wait.
+
+    Because launch and resume share this block, a resumed worker's pid identity is
+    refreshed exactly like a launched one -- so poll() liveness always tracks the
+    CURRENT codex process, never a resumed worker's dead original invocation.
+    """
+    tee = f"tee -a {shlex.quote(log_name)}" if append_log else f"tee {shlex.quote(log_name)}"
+    sid_capture = ""
+    if sid_path is not None:  # only launch needs to discover the id; resume reuses it
+        sid_capture = f"""# race-free session id: codex prints it into THIS worker's own log at startup
+( for _ in $(seq 1 {delay}); do
+    sid=$(grep -oiE 'session id: [0-9a-f-]{{36}}' {shlex.quote(log_name)} 2>/dev/null | grep -oE '[0-9a-f-]{{36}}' | head -1)
+    [ -n "$sid" ] && {{ echo "$sid" > {shlex.quote(sid_path)}; break; }}
+    sleep 1
+  done ) &
+"""
+    return f"""{invocation} > >({tee}) 2>&1 &
+_CPID=$!
+_ST=$(awk '{{s=substr($0,index($0,") ")+2); n=split(s,a," "); print a[20]}}' /proc/$_CPID/stat 2>/dev/null)
+echo "$_CPID $_ST" > {shlex.quote(pid_file)}
+{sid_capture}wait $_CPID
+"""
+
+
 def render_launch_script(
     *, cfg: CodexClusterConfig, workspace: str, worker_id: str, task_id: str,
     lease_id: str, receipt_path: str, brief: str, log_name: str, sid_path: str,
     pid_file: str,
 ) -> str:
     """Headless-codex launch mirroring the proven RESTART_HEADLESS.sh, plus the
-    runtime env + receipt protocol.
-
-    Worker identity: codex is started in the background so its exact pid is known;
-    the pid and its /proc start-time are written to `pid_file` as a stable
-    (pid,starttime) identity (liveness is per-worker, never a workspace-wide
-    pgrep). Session-id capture greps the session id codex prints at startup into
-    THIS worker's own (per-worker) log -- race-free even when several codex
-    workers start concurrently, and with no dependence on the shared sessions dir.
-    """
+    runtime env + receipt protocol. Records (pid,starttime) identity and captures
+    the session id from this worker's own log (see _run_and_record)."""
     full_brief = brief.rstrip() + "\n\n" + receipt_instruction(receipt_path)
-    delay = cfg.session_id_capture_delay
+    body = _run_and_record(
+        invocation=f"{cfg.codex_cmd} {shlex.quote(full_brief)}",
+        log_name=log_name, pid_file=pid_file, sid_path=sid_path,
+        append_log=False, delay=cfg.session_id_capture_delay,
+    )
     return f"""#!/bin/bash
 cd {shlex.quote(workspace)}
 {_prelude(cfg)}{_env_exports(worker_id, task_id, lease_id, receipt_path)}
 rm -f {shlex.quote(receipt_path)}
-{cfg.codex_cmd} {shlex.quote(full_brief)} > >(tee {shlex.quote(log_name)}) 2>&1 &
-_CPID=$!
-_ST=$(awk '{{s=substr($0,index($0,") ")+2); n=split(s,a," "); print a[20]}}' /proc/$_CPID/stat 2>/dev/null)
-echo "$_CPID $_ST" > {shlex.quote(pid_file)}
-# race-free session id: codex prints it into THIS worker's own log at startup
-( for _ in $(seq 1 {delay}); do
-    sid=$(grep -oiE 'session id: [0-9a-f-]{{36}}' {shlex.quote(log_name)} 2>/dev/null | grep -oE '[0-9a-f-]{{36}}' | head -1)
-    [ -n "$sid" ] && {{ echo "$sid" > {shlex.quote(sid_path)}; break; }}
-    sleep 1
-  done ) &
-wait $_CPID
-"""
+{body}"""
 
 
 def render_resume_script(
     *, cfg: CodexClusterConfig, workspace: str, worker_id: str, task_id: str,
     lease_id: str, receipt_path: str, sid_path: str, log_name: str, wake_msg: str,
+    pid_file: str,
 ) -> str:
-    """Resume an existing codex session (mirrors WAKE.sh) under the same lease."""
+    """Resume an existing codex session (mirrors WAKE.sh) under the same lease.
+
+    Uses the SAME _run_and_record tail as launch, so the resumed process's
+    (pid,starttime) identity is written to `pid_file`; poll() then sees the live
+    resumed process instead of the dead original (the bug this fixes)."""
     full_msg = wake_msg.rstrip() + "\n\n" + receipt_instruction(receipt_path)
+    body = _run_and_record(
+        invocation=f'{cfg.codex_cmd} resume "$SID" {shlex.quote(full_msg)}',
+        log_name=log_name, pid_file=pid_file, sid_path=None,  # id unchanged on resume
+        append_log=True, delay=cfg.session_id_capture_delay,
+    )
     return f"""#!/bin/bash
 cd {shlex.quote(workspace)}
 {_prelude(cfg)}{_env_exports(worker_id, task_id, lease_id, receipt_path)}
 rm -f {shlex.quote(receipt_path)}
 SID=$(cat {shlex.quote(sid_path)} 2>/dev/null)
 if [ -z "$SID" ]; then echo "no session id at {sid_path}; cannot resume" >&2; exit 3; fi
-{cfg.codex_cmd} resume "$SID" {shlex.quote(full_msg)} 2>&1 | tee -a {shlex.quote(log_name)}
-"""
+{body}"""
 
 
 # --- liveness (default; injectable) -----------------------------------------
@@ -267,7 +297,9 @@ class CodexTmuxExecutor:
         if not ws or not brief:
             raise ValueError(f"task {task.id} needs metadata.workspace and metadata.brief")
         wid = lease.worker_id
-        window = task.metadata.get("agent_label") or wid
+        # tmux pane identity is the WORKER id, not a human agent_label: each worker
+        # generation gets its own unambiguous pane, so generations never collide.
+        window = wid
         workspace = str(Path(ws).resolve())
 
         # idempotent per lease: never start a second codex for THIS live worker
@@ -307,7 +339,7 @@ class CodexTmuxExecutor:
         resume_sh.write_text(render_resume_script(
             cfg=self.config, workspace=st["workspace"], worker_id=worker_id, task_id=task.id,
             lease_id=lease.lease_id, receipt_path=st["receipt_path"],
-            sid_path=st["sid_path"], log_name=st["log_name"],
+            sid_path=st["sid_path"], log_name=st["log_name"], pid_file=st["pid_file"],
             wake_msg=("Wake-up: a condition you were awaiting has fired or a new "
                       "MASTER_*.md landed. Re-scan your workspace, verify the awaited "
                       "state, acknowledge in LEDGER, and continue."),

--- a/src/agent_farm_runtime/adapters/fake.py
+++ b/src/agent_farm_runtime/adapters/fake.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from ..models import Lease, Receipt, Task
+from .base import LaunchHandle, WorkerObservation
+
+
+class FakeExecutor:
+    """In-process, scriptable executor for tests.
+
+    Records launches and returns programmed observations. Tests drive it with
+    set_receipt() and kill() to simulate worker behavior and crashes without any
+    real process, tmux, or codex.
+    """
+
+    def __init__(self) -> None:
+        self.launched: list[tuple[str, str]] = []   # (worker_id, task_id)
+        self.resumed: list[str] = []
+        self.stopped: list[str] = []
+        self._alive: dict[str, bool] = {}
+        self._receipt: dict[str, Receipt] = {}
+        self._task: dict[str, str] = {}
+
+    # WorkerExecutor protocol -------------------------------------------------
+
+    def launch(self, task: Task, lease: Lease) -> LaunchHandle:
+        wid = lease.worker_id
+        self.launched.append((wid, task.id))
+        self._alive[wid] = True
+        self._task[wid] = task.id
+        return LaunchHandle(worker_id=wid, session_handle=f"fake:{wid}")
+
+    def resume(self, task: Task, worker_id: str, lease: Lease) -> None:
+        self.resumed.append(worker_id)
+        self._alive[worker_id] = True
+
+    def poll(self, worker_id: str) -> WorkerObservation:
+        return WorkerObservation(
+            worker_id=worker_id,
+            alive=self._alive.get(worker_id, False),
+            receipt=self._receipt.get(worker_id),
+        )
+
+    def stop(self, worker_id: str) -> None:
+        self.stopped.append(worker_id)
+        self._alive[worker_id] = False
+
+    # test controls -----------------------------------------------------------
+
+    def set_receipt(self, receipt: Receipt) -> None:
+        self._receipt[receipt.worker_id] = receipt
+
+    def clear_receipt(self, worker_id: str) -> None:
+        self._receipt.pop(worker_id, None)
+
+    def kill(self, worker_id: str) -> None:
+        self._alive[worker_id] = False

--- a/src/agent_farm_runtime/adapters/local_process.py
+++ b/src/agent_farm_runtime/adapters/local_process.py
@@ -46,8 +46,24 @@ class LocalProcessExecutor:
         except ValueError:
             return None
 
+    def _pid_alive(self, worker_id: str) -> bool:
+        pid = self._read_pid(worker_id)
+        if pid is None:
+            return False
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
     def launch(self, task: Task, lease: Lease) -> LaunchHandle:
         wid = lease.worker_id
+        # idempotent for a given lease: if this worker is already running, do not
+        # start a second process (crash-consistency defense-in-depth).
+        if self._pid_alive(wid):
+            return LaunchHandle(worker_id=wid, session_handle=f"pid:{self._read_pid(wid)}")
         receipt_path = self._receipt_path(wid)
         # fresh generation: do not inherit a stale receipt file
         receipt_path.unlink(missing_ok=True)

--- a/src/agent_farm_runtime/adapters/local_process.py
+++ b/src/agent_farm_runtime/adapters/local_process.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 from ..models import Lease, Receipt, Task
+from ..procutil import pid_identity_alive, proc_starttime, read_pidfile, reap_children
 from .base import LaunchHandle, WorkerObservation
 
 
@@ -15,14 +16,13 @@ class LocalProcessExecutor:
 
     This is the first NON-fake executor: it proves the reconciler can launch,
     observe, fence, and adopt an actual process — without depending on codex or
-    tmux. It is the honest stepping stone to CodexTmuxExecutor (which specializes
-    launch/resume to a tmux window running `codex exec`).
+    tmux. It is the honest stepping stone to CodexTmuxExecutor.
 
-    A worker is a subprocess running `task.metadata["command"]` (a shell string).
-    The command is handed, via env, everything it needs to write a fenced
-    receipt: FARM_RECEIPT_PATH, FARM_WORKER_ID, FARM_TASK_ID, FARM_LEASE_ID.
-    A cooperative worker writes its receipt there; the executor reads it back and
-    checks liveness by pid. Receipts live under <runtime>/receipts/<worker>.json.
+    A worker is a subprocess running `task.metadata["command"]` (a shell string),
+    handed via env everything it needs to write a fenced receipt: FARM_RECEIPT_PATH,
+    FARM_WORKER_ID, FARM_TASK_ID, FARM_LEASE_ID. Liveness uses a (pid, starttime)
+    identity file, so a recycled pid is never mistaken for a live worker, and
+    exited children are reaped so a `--loop` reconciler does not leak zombies.
     """
 
     def __init__(self, runtime_dir: Path):
@@ -37,36 +37,24 @@ class LocalProcessExecutor:
     def _pid_path(self, worker_id: str) -> Path:
         return self.procs_dir / f"{worker_id}.pid"
 
-    def _read_pid(self, worker_id: str) -> int | None:
+    def _identity(self, worker_id: str) -> tuple[int | None, int | None]:
         p = self._pid_path(worker_id)
-        if not p.exists():
-            return None
-        try:
-            return int(p.read_text().strip())
-        except ValueError:
-            return None
+        return read_pidfile(str(p)) if p.exists() else (None, None)
 
-    def _pid_alive(self, worker_id: str) -> bool:
-        pid = self._read_pid(worker_id)
-        if pid is None:
-            return False
-        try:
-            os.kill(pid, 0)
-            return True
-        except ProcessLookupError:
-            return False
-        except PermissionError:
-            return True
+    def _alive(self, worker_id: str) -> bool:
+        reap_children()  # clear zombies before judging liveness
+        pid, start = self._identity(worker_id)
+        return pid_identity_alive(pid, start)
 
     def launch(self, task: Task, lease: Lease) -> LaunchHandle:
         wid = lease.worker_id
-        # idempotent for a given lease: if this worker is already running, do not
-        # start a second process (crash-consistency defense-in-depth).
-        if self._pid_alive(wid):
-            return LaunchHandle(worker_id=wid, session_handle=f"pid:{self._read_pid(wid)}")
+        # idempotent for a given lease: if THIS worker (pid+starttime) is already
+        # running, do not start a second process.
+        if self._alive(wid):
+            pid, _ = self._identity(wid)
+            return LaunchHandle(worker_id=wid, session_handle=f"pid:{pid}")
         receipt_path = self._receipt_path(wid)
-        # fresh generation: do not inherit a stale receipt file
-        receipt_path.unlink(missing_ok=True)
+        receipt_path.unlink(missing_ok=True)  # fresh generation: no stale receipt
         env = dict(os.environ)
         env.update(
             FARM_RECEIPT_PATH=str(receipt_path),
@@ -78,18 +66,16 @@ class LocalProcessExecutor:
         if not command:
             raise ValueError(f"task {task.id} has no metadata.command for LocalProcessExecutor")
         proc = subprocess.Popen(
-            command,
-            shell=True,
-            env=env,
-            cwd=task.metadata.get("cwd") or None,
-            start_new_session=True,
+            command, shell=True, env=env,
+            cwd=task.metadata.get("cwd") or None, start_new_session=True,
         )
-        self._pid_path(wid).write_text(str(proc.pid))
+        # record a stable identity: pid + start-time, so pid reuse cannot alias it
+        self._pid_path(wid).write_text(f"{proc.pid} {proc_starttime(proc.pid)}")
         return LaunchHandle(worker_id=wid, session_handle=f"pid:{proc.pid}")
 
     def resume(self, task: Task, worker_id: str, lease: Lease) -> None:
-        # Local processes are not re-woken; a WAITING->RUNNING resume for a
-        # crashed local worker is handled by adoption (relaunch) instead.
+        # Local processes are not re-woken; a crashed local worker is re-actuated
+        # by adoption (relaunch) instead.
         return None
 
     def poll(self, worker_id: str) -> WorkerObservation:
@@ -100,23 +86,15 @@ class LocalProcessExecutor:
                 receipt = Receipt.from_dict(json.loads(rp.read_text()))
             except (ValueError, KeyError):
                 receipt = None
-        pid = self._read_pid(worker_id)
-        alive = False
-        if pid is not None:
-            try:
-                os.kill(pid, 0)
-                alive = True
-            except ProcessLookupError:
-                alive = False
-            except PermissionError:
-                alive = True
-        return WorkerObservation(worker_id=worker_id, alive=alive, receipt=receipt)
+        return WorkerObservation(worker_id=worker_id, alive=self._alive(worker_id), receipt=receipt)
 
     def stop(self, worker_id: str) -> None:
-        pid = self._read_pid(worker_id)
-        if pid is None:
+        pid, start = self._identity(worker_id)
+        if not pid_identity_alive(pid, start):  # only signal the process we launched
+            reap_children()
             return
         try:
             os.killpg(os.getpgid(pid), signal.SIGTERM)
         except (ProcessLookupError, PermissionError):
             pass
+        reap_children()

--- a/src/agent_farm_runtime/adapters/local_process.py
+++ b/src/agent_farm_runtime/adapters/local_process.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+from pathlib import Path
+
+from ..models import Lease, Receipt, Task
+from .base import LaunchHandle, WorkerObservation
+
+
+class LocalProcessExecutor:
+    """Drives real OS subprocesses as disposable workers.
+
+    This is the first NON-fake executor: it proves the reconciler can launch,
+    observe, fence, and adopt an actual process — without depending on codex or
+    tmux. It is the honest stepping stone to CodexTmuxExecutor (which specializes
+    launch/resume to a tmux window running `codex exec`).
+
+    A worker is a subprocess running `task.metadata["command"]` (a shell string).
+    The command is handed, via env, everything it needs to write a fenced
+    receipt: FARM_RECEIPT_PATH, FARM_WORKER_ID, FARM_TASK_ID, FARM_LEASE_ID.
+    A cooperative worker writes its receipt there; the executor reads it back and
+    checks liveness by pid. Receipts live under <runtime>/receipts/<worker>.json.
+    """
+
+    def __init__(self, runtime_dir: Path):
+        self.receipts_dir = Path(runtime_dir) / "receipts"
+        self.receipts_dir.mkdir(parents=True, exist_ok=True)
+        self.procs_dir = Path(runtime_dir) / "procs"
+        self.procs_dir.mkdir(parents=True, exist_ok=True)
+
+    def _receipt_path(self, worker_id: str) -> Path:
+        return self.receipts_dir / f"{worker_id}.json"
+
+    def _pid_path(self, worker_id: str) -> Path:
+        return self.procs_dir / f"{worker_id}.pid"
+
+    def _read_pid(self, worker_id: str) -> int | None:
+        p = self._pid_path(worker_id)
+        if not p.exists():
+            return None
+        try:
+            return int(p.read_text().strip())
+        except ValueError:
+            return None
+
+    def launch(self, task: Task, lease: Lease) -> LaunchHandle:
+        wid = lease.worker_id
+        receipt_path = self._receipt_path(wid)
+        # fresh generation: do not inherit a stale receipt file
+        receipt_path.unlink(missing_ok=True)
+        env = dict(os.environ)
+        env.update(
+            FARM_RECEIPT_PATH=str(receipt_path),
+            FARM_WORKER_ID=wid,
+            FARM_TASK_ID=task.id,
+            FARM_LEASE_ID=lease.lease_id,
+        )
+        command = task.metadata.get("command")
+        if not command:
+            raise ValueError(f"task {task.id} has no metadata.command for LocalProcessExecutor")
+        proc = subprocess.Popen(
+            command,
+            shell=True,
+            env=env,
+            cwd=task.metadata.get("cwd") or None,
+            start_new_session=True,
+        )
+        self._pid_path(wid).write_text(str(proc.pid))
+        return LaunchHandle(worker_id=wid, session_handle=f"pid:{proc.pid}")
+
+    def resume(self, task: Task, worker_id: str, lease: Lease) -> None:
+        # Local processes are not re-woken; a WAITING->RUNNING resume for a
+        # crashed local worker is handled by adoption (relaunch) instead.
+        return None
+
+    def poll(self, worker_id: str) -> WorkerObservation:
+        receipt = None
+        rp = self._receipt_path(worker_id)
+        if rp.exists():
+            try:
+                receipt = Receipt.from_dict(json.loads(rp.read_text()))
+            except (ValueError, KeyError):
+                receipt = None
+        pid = self._read_pid(worker_id)
+        alive = False
+        if pid is not None:
+            try:
+                os.kill(pid, 0)
+                alive = True
+            except ProcessLookupError:
+                alive = False
+            except PermissionError:
+                alive = True
+        return WorkerObservation(worker_id=worker_id, alive=alive, receipt=receipt)
+
+    def stop(self, worker_id: str) -> None:
+        pid = self._read_pid(worker_id)
+        if pid is None:
+            return
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass

--- a/src/agent_farm_runtime/cli.py
+++ b/src/agent_farm_runtime/cli.py
@@ -47,6 +47,15 @@ def cmd_task_create(args: argparse.Namespace) -> int:
         metadata["command"] = args.command
     if args.cwd:
         metadata["cwd"] = args.cwd
+    if args.workspace:
+        metadata["workspace"] = args.workspace
+    brief = args.brief
+    if args.brief_file:
+        brief = Path(args.brief_file).read_text()
+    if brief:
+        metadata["brief"] = brief
+    if args.agent_label:
+        metadata["agent_label"] = args.agent_label
     task = Task(
         id=task_id,
         objective=args.objective,
@@ -138,6 +147,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--acceptance", required=True)
     p.add_argument("--command", help="worker command (metadata.command) for the local-process executor")
     p.add_argument("--cwd", help="working directory for the worker command")
+    p.add_argument("--workspace", help="abs workspace dir (metadata.workspace) for the codex-tmux executor")
+    p.add_argument("--brief", help="agent-facing brief (metadata.brief) for the codex-tmux executor")
+    p.add_argument("--brief-file", help="read the agent brief from this file")
+    p.add_argument("--agent-label", help="tmux window name for the codex-tmux worker")
     p.set_defaults(func=cmd_task_create)
     p = sub.add_parser("task-list", help="list task contracts")
     p.set_defaults(func=cmd_task_list)

--- a/src/agent_farm_runtime/cli.py
+++ b/src/agent_farm_runtime/cli.py
@@ -71,6 +71,7 @@ def cmd_task_create(args: argparse.Namespace) -> int:
 def cmd_reconcile(args: argparse.Namespace) -> int:
     import time
 
+    from .locking import ReconcilerBusy, single_reconciler
     from .reconciler import Reconciler
 
     paths = FarmPaths(farm_root(Path(args.project)))
@@ -83,7 +84,7 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
     else:
         from .adapters.local_process import LocalProcessExecutor
         executor = LocalProcessExecutor(paths.runtime)
-    reconciler = Reconciler(paths, executor)
+    reconciler = Reconciler(paths, executor, grace_seconds=args.grace_seconds)
 
     def one_pass() -> None:
         rep = reconciler.reconcile_once()
@@ -94,14 +95,21 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
             "resumed": rep.resumed,
             "heartbeats": rep.heartbeats,
             "ignored_stale": rep.ignored_stale,
+            "waiting_grace": rep.waiting_grace,
         }, sort_keys=True))
 
-    if not args.loop:
-        one_pass()
-        return 0
-    while True:
-        one_pass()
-        time.sleep(args.interval)
+    # INV-6: at most one reconciler mutates a farm at a time.
+    try:
+        with single_reconciler(paths.runtime):
+            if not args.loop:
+                one_pass()
+                return 0
+            while True:
+                one_pass()
+                time.sleep(args.interval)
+    except ReconcilerBusy as exc:
+        print(f"reconciler busy: {exc}")
+        return 1
 
 
 def cmd_task_list(args: argparse.Namespace) -> int:
@@ -164,6 +172,8 @@ def build_parser() -> argparse.ArgumentParser:
                    default="local-process", help="worker backend (default: local-process)")
     p.add_argument("--session", default="farm2", help="tmux session for codex-tmux (never the live `farm`)")
     p.add_argument("--tmux-socket", default=None, help="dedicated tmux server socket (-L) for isolation")
+    p.add_argument("--grace-seconds", type=float, default=60.0,
+                   help="seconds a leased worker may be unobserved before its lease is rotated")
     p.add_argument("--loop", action="store_true", help="run continuously instead of one pass")
     p.add_argument("--interval", type=float, default=10.0, help="seconds between passes in --loop")
     p.set_defaults(func=cmd_reconcile)

--- a/src/agent_farm_runtime/cli.py
+++ b/src/agent_farm_runtime/cli.py
@@ -42,10 +42,51 @@ def cmd_task_create(args: argparse.Namespace) -> int:
     paths = FarmPaths(farm_root(Path(args.project)))
     paths.ensure()
     task_id = args.id or f"T-{uuid.uuid4().hex[:8]}"
-    task = Task(id=task_id, objective=args.objective, deliverable=args.deliverable, acceptance=args.acceptance)
+    metadata: dict = {}
+    if args.command:
+        metadata["command"] = args.command
+    if args.cwd:
+        metadata["cwd"] = args.cwd
+    task = Task(
+        id=task_id,
+        objective=args.objective,
+        deliverable=args.deliverable,
+        acceptance=args.acceptance,
+        metadata=metadata,
+    )
     TaskStore(paths).create(task)
     print(task_id)
     return 0
+
+
+def cmd_reconcile(args: argparse.Namespace) -> int:
+    import time
+
+    from .adapters.local_process import LocalProcessExecutor
+    from .reconciler import Reconciler
+
+    paths = FarmPaths(farm_root(Path(args.project)))
+    paths.ensure()
+    executor = LocalProcessExecutor(paths.runtime)
+    reconciler = Reconciler(paths, executor)
+
+    def one_pass() -> None:
+        rep = reconciler.reconcile_once()
+        print(json.dumps({
+            "launched": rep.launched,
+            "adopted": rep.adopted,
+            "advanced": rep.advanced,
+            "resumed": rep.resumed,
+            "heartbeats": rep.heartbeats,
+            "ignored_stale": rep.ignored_stale,
+        }, sort_keys=True))
+
+    if not args.loop:
+        one_pass()
+        return 0
+    while True:
+        one_pass()
+        time.sleep(args.interval)
 
 
 def cmd_task_list(args: argparse.Namespace) -> int:
@@ -89,6 +130,8 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--objective", required=True)
     p.add_argument("--deliverable", required=True)
     p.add_argument("--acceptance", required=True)
+    p.add_argument("--command", help="worker command (metadata.command) for the local-process executor")
+    p.add_argument("--cwd", help="working directory for the worker command")
     p.set_defaults(func=cmd_task_create)
     p = sub.add_parser("task-list", help="list task contracts")
     p.set_defaults(func=cmd_task_list)
@@ -97,6 +140,10 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("shadow", help="read-only shadow observation of existing workspaces")
     p.add_argument("workspaces")
     p.set_defaults(func=cmd_shadow)
+    p = sub.add_parser("reconcile", help="run the actuating control loop (local-process executor)")
+    p.add_argument("--loop", action="store_true", help="run continuously instead of one pass")
+    p.add_argument("--interval", type=float, default=10.0, help="seconds between passes in --loop")
+    p.set_defaults(func=cmd_reconcile)
     return parser
 
 

--- a/src/agent_farm_runtime/cli.py
+++ b/src/agent_farm_runtime/cli.py
@@ -62,12 +62,18 @@ def cmd_task_create(args: argparse.Namespace) -> int:
 def cmd_reconcile(args: argparse.Namespace) -> int:
     import time
 
-    from .adapters.local_process import LocalProcessExecutor
     from .reconciler import Reconciler
 
     paths = FarmPaths(farm_root(Path(args.project)))
     paths.ensure()
-    executor = LocalProcessExecutor(paths.runtime)
+    if args.executor == "codex-tmux":
+        from .adapters.codex import CodexTmuxExecutor
+        executor = CodexTmuxExecutor(
+            paths.runtime, session=args.session, tmux_socket=args.tmux_socket
+        )
+    else:
+        from .adapters.local_process import LocalProcessExecutor
+        executor = LocalProcessExecutor(paths.runtime)
     reconciler = Reconciler(paths, executor)
 
     def one_pass() -> None:
@@ -140,7 +146,11 @@ def build_parser() -> argparse.ArgumentParser:
     p = sub.add_parser("shadow", help="read-only shadow observation of existing workspaces")
     p.add_argument("workspaces")
     p.set_defaults(func=cmd_shadow)
-    p = sub.add_parser("reconcile", help="run the actuating control loop (local-process executor)")
+    p = sub.add_parser("reconcile", help="run the actuating control loop")
+    p.add_argument("--executor", choices=["local-process", "codex-tmux"],
+                   default="local-process", help="worker backend (default: local-process)")
+    p.add_argument("--session", default="farm2", help="tmux session for codex-tmux (never the live `farm`)")
+    p.add_argument("--tmux-socket", default=None, help="dedicated tmux server socket (-L) for isolation")
     p.add_argument("--loop", action="store_true", help="run continuously instead of one pass")
     p.add_argument("--interval", type=float, default=10.0, help="seconds between passes in --loop")
     p.set_defaults(func=cmd_reconcile)

--- a/src/agent_farm_runtime/doctor.py
+++ b/src/agent_farm_runtime/doctor.py
@@ -21,8 +21,21 @@ def run_doctor(paths: FarmPaths) -> list[Check]:
 
     lease_ids: set[str] = set()
     worker_to_task: dict[str, str] = {}
+    active_workspace: dict[str, str] = {}
 
     for task in tasks:
+        # A workspace is one agent's mutable state (LEDGER, .session_id, MASTER
+        # notes); two concurrently-active tasks must never share one, or their
+        # workers would corrupt each other. Forbid it as a hard invariant.
+        if task.state in {TaskState.RUNNING, TaskState.WAITING}:
+            ws = task.metadata.get("workspace")
+            if ws:
+                if ws in active_workspace:
+                    checks.append(Check("FAIL", f"workspace {ws} shared by active tasks "
+                                                 f"{active_workspace[ws]} and {task.id}"))
+                else:
+                    active_workspace[ws] = task.id
+
         if task.lease:
             if task.lease.lease_id in lease_ids:
                 checks.append(Check("FAIL", f"duplicate lease id {task.lease.lease_id}"))

--- a/src/agent_farm_runtime/locking.py
+++ b/src/agent_farm_runtime/locking.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import os
+from pathlib import Path
+
+
+class ReconcilerBusy(RuntimeError):
+    """Another reconciler already holds the exclusive lock for this farm."""
+
+
+@contextlib.contextmanager
+def single_reconciler(runtime_dir: Path):
+    """Enforce INV-6 (serialized reconciliation) with an OS advisory lock.
+
+    A non-blocking exclusive flock on <runtime>/reconcile.lock guarantees at most
+    one reconciler mutates a given farm at a time, so two `farm reconcile`
+    processes cannot race on the same READY task. Advisory + local-fs only, which
+    is sufficient for a single-host farm; a distributed farm would need a fenced
+    lease service instead (deferred).
+    """
+    runtime_dir = Path(runtime_dir)
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = runtime_dir / "reconcile.lock"
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise ReconcilerBusy(
+                f"another reconciler holds {lock_path}; refusing to run concurrently"
+            ) from exc
+        os.ftruncate(fd, 0)
+        os.write(fd, f"{os.getpid()}\n".encode())
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)

--- a/src/agent_farm_runtime/models.py
+++ b/src/agent_farm_runtime/models.py
@@ -87,3 +87,45 @@ class Event:
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+class ReceiptStatus(StrEnum):
+    """What a worker reports about the unit of work it was leased to do.
+
+    This is the structured receipt primitive (V2_DESIGN deferred item, minimal
+    form). A worker never reports DONE: DONE requires recorded acceptance, which
+    is a master/harness judgment, not a worker claim (Layer-1/Layer-2 boundary).
+    """
+
+    RUNNING = "RUNNING"      # heartbeat; still executing -> task stays RUNNING
+    AWAITING = "AWAITING"    # reached a named wait boundary -> RUNNING->WAITING
+    SUBMITTED = "SUBMITTED"  # produced the final deliverable -> RUNNING->SUBMITTED
+    FAILED = "FAILED"        # unrecoverable -> RUNNING->FAILED
+
+
+@dataclass(frozen=True)
+class Receipt:
+    """A worker's structured report, fenced by lease_id.
+
+    The reconciler MUST ignore any receipt whose lease_id does not match the
+    task's authoritative lease (a receipt from a superseded worker generation).
+    """
+
+    worker_id: str
+    task_id: str
+    lease_id: str
+    status: ReceiptStatus
+    ts: str
+    note: str = ""
+    waiting_on: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["status"] = self.status.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Receipt":
+        data = dict(data)
+        data["status"] = ReceiptStatus(data["status"])
+        return cls(**data)

--- a/src/agent_farm_runtime/procutil.py
+++ b/src/agent_farm_runtime/procutil.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+
+
+def proc_starttime(pid: int) -> int | None:
+    """Linux process start-time (jiffies since boot; /proc/<pid>/stat field 22).
+
+    (pid, starttime) is a stable, unique process identity for the life of a boot:
+    it distinguishes a live process from a DIFFERENT process that later reused the
+    same pid. `comm` may contain spaces/parens, so parse after the final ')'.
+    """
+    try:
+        with open(f"/proc/{pid}/stat", encoding="utf-8") as fh:
+            data = fh.read()
+    except (FileNotFoundError, ProcessLookupError, OSError):
+        return None
+    try:
+        after = data[data.rindex(")") + 2:].split()
+        return int(after[19])  # field 22 == starttime; after ')' starts at field 3
+    except (ValueError, IndexError):
+        return None
+
+
+def pid_identity_alive(pid: int | None, starttime: int | None) -> bool:
+    """True iff `pid` is alive AND (when known) is the SAME process we launched.
+
+    A recorded starttime that no longer matches means the pid was recycled to a
+    different process -> treat as dead. Without a recorded starttime, fall back to
+    plain liveness.
+    """
+    if pid is None:
+        return False
+    current = proc_starttime(pid)
+    if current is None:
+        return False
+    if starttime is None:
+        return True
+    return current == starttime
+
+
+def read_pidfile(path: str) -> tuple[int | None, int | None]:
+    """Parse a '<pid> <starttime>' identity file. Missing/garbled -> (None, None)."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            parts = fh.read().split()
+    except (FileNotFoundError, OSError):
+        return None, None
+    try:
+        pid = int(parts[0])
+    except (IndexError, ValueError):
+        return None, None
+    start = None
+    if len(parts) > 1:
+        try:
+            start = int(parts[1])
+        except ValueError:
+            start = None
+    return pid, start
+
+
+def reap_children() -> None:
+    """Best-effort reap of any exited children, so a long-lived reconciler --loop
+    does not accumulate zombies for workers it launched and no longer tracks."""
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        except OSError:
+            return
+        if pid == 0:
+            return

--- a/src/agent_farm_runtime/reconciler.py
+++ b/src/agent_farm_runtime/reconciler.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from .adapters.base import WorkerExecutor
+from .events import EventLog
+from .models import (
+    Event,
+    Lease,
+    Receipt,
+    ReceiptStatus,
+    Task,
+    TaskState,
+    Worker,
+    WorkerState,
+)
+from .store import FarmPaths, TaskStore, WorkerRegistry
+from .transitions import acquire_lease, rotate_lease, transition_task
+
+# States from which a worker's structured receipt drives the next state.
+_RECEIPT_TARGET = {
+    ReceiptStatus.AWAITING: TaskState.WAITING,
+    ReceiptStatus.SUBMITTED: TaskState.SUBMITTED,
+    ReceiptStatus.FAILED: TaskState.FAILED,
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class ReconcileReport:
+    launched: list[str] = field(default_factory=list)       # task ids newly actuated
+    adopted: list[str] = field(default_factory=list)        # task ids re-actuated after crash
+    advanced: list[tuple[str, str]] = field(default_factory=list)  # (task, new state)
+    resumed: list[str] = field(default_factory=list)        # WAITING->RUNNING
+    heartbeats: list[str] = field(default_factory=list)     # worker ids seen alive
+    ignored_stale: list[str] = field(default_factory=list)  # fenced-out receipts (worker ids)
+
+
+class Reconciler:
+    """Serialized, idempotent control loop (INV-6).
+
+    One `reconcile_once` call is a single pass over authoritative task state; it
+    is the only thing that actuates workers. It:
+      1. actuates READY tasks (mint lease, launch worker, READY->RUNNING);
+      2. applies fenced receipts from live workers (RUNNING->WAITING/SUBMITTED/FAILED);
+      3. adopts crashed RUNNING tasks (rotate lease off the dead worker, relaunch);
+      4. resumes WAITING tasks whose unblock predicate fires;
+      5. repairs the observed Worker Registry to match Task.lease + liveness.
+    All state mutation goes through transitions/lease helpers; the registry is
+    observed-only and never authoritative.
+    """
+
+    def __init__(
+        self,
+        paths: FarmPaths,
+        executor: WorkerExecutor,
+        *,
+        actor: str = "reconciler",
+        clock: Callable[[], str] = _now,
+        unblock: Callable[[Task], bool] | None = None,
+    ):
+        self.paths = paths
+        self.executor = executor
+        self.actor = actor
+        self.clock = clock
+        self.unblock = unblock
+        self.tasks = TaskStore(paths)
+        self.registry = WorkerRegistry(paths)
+        self.events = EventLog(paths.events / "log.ndjson")
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _emit(self, task_id: str, type_: str, payload: dict) -> None:
+        self.events.append(
+            Event(
+                id=uuid.uuid4().hex,
+                task_id=task_id,
+                type=type_,
+                actor=self.actor,
+                payload=payload,
+                ts=self.clock(),
+            )
+        )
+
+    def _mint_lease(self, worker_id: str) -> Lease:
+        return Lease(worker_id=worker_id, lease_id=uuid.uuid4().hex)
+
+    def _observe_worker(self, worker_id: str, handle: str | None, task_id: str, lease_id: str, alive: bool) -> None:
+        self.registry.put_observed(
+            Worker(
+                id=worker_id,
+                session_handle=handle,
+                heartbeat=self.clock(),
+                lease={"task_id": task_id, "lease_id": lease_id},
+                state=WorkerState.BUSY if alive else WorkerState.DEAD,
+            )
+        )
+
+    # -- individual task handlers ---------------------------------------------
+
+    def _actuate_ready(self, task: Task, report: ReconcileReport) -> None:
+        worker_id = f"W-{task.id}-{uuid.uuid4().hex[:6]}"
+        lease = self._mint_lease(worker_id)
+        leased = acquire_lease(task, lease)
+        handle = self.executor.launch(leased, lease)
+        started = transition_task(
+            leased, TaskState.RUNNING, lease_id=lease.lease_id, new_lease=lease
+        )
+        self.tasks.put_authoritative(started)
+        self._observe_worker(worker_id, handle.session_handle, task.id, lease.lease_id, alive=True)
+        self._emit(task.id, "WORKER_LAUNCHED", {"worker_id": worker_id, "lease_id": lease.lease_id})
+        report.launched.append(task.id)
+
+    def _apply_receipt(self, task: Task, receipt: Receipt, report: ReconcileReport) -> bool:
+        """Apply a fenced receipt to a RUNNING task. Returns True if state changed."""
+        if receipt.status is ReceiptStatus.RUNNING:
+            self._observe_worker(
+                receipt.worker_id, None, task.id, task.lease.lease_id, alive=True
+            )
+            report.heartbeats.append(receipt.worker_id)
+            return False
+
+        target = _RECEIPT_TARGET[receipt.status]
+        patch: dict = {"last_receipt_note": receipt.note}
+        if target is TaskState.WAITING:
+            patch["waiting_on"] = receipt.waiting_on or "unspecified"
+        # SUBMITTED/FAILED/WAITING: keep the lease on WAITING (same worker may
+        # resume); release it on SUBMITTED/FAILED so no worker lingers as owner.
+        new_lease: object = task.lease if target is TaskState.WAITING else None
+        advanced = transition_task(
+            task,
+            target,
+            lease_id=task.lease.lease_id,
+            metadata_patch=patch,
+            new_lease=new_lease,
+        )
+        self.tasks.put_authoritative(advanced)
+        if target is not TaskState.WAITING:
+            self.executor.stop(receipt.worker_id)
+            self._observe_worker(
+                receipt.worker_id, None, task.id, task.lease.lease_id, alive=False
+            )
+        else:
+            self._observe_worker(
+                receipt.worker_id, None, task.id, task.lease.lease_id, alive=True
+            )
+        self._emit(
+            task.id,
+            "RECEIPT_APPLIED",
+            {"worker_id": receipt.worker_id, "status": receipt.status.value, "to": target.value},
+        )
+        report.advanced.append((task.id, target.value))
+        return True
+
+    def _adopt_crashed(self, task: Task, report: ReconcileReport) -> None:
+        dead = task.lease.worker_id
+        self.executor.stop(dead)  # best-effort fence of the dead generation
+        released = rotate_lease(task, dead_worker_id=dead)
+        self.tasks.put_authoritative(released)
+        self._emit(task.id, "LEASE_ROTATED", {"dead_worker_id": dead})
+        # re-actuate onto a fresh worker; state is preserved (still RUNNING)
+        worker_id = f"W-{task.id}-{uuid.uuid4().hex[:6]}"
+        lease = self._mint_lease(worker_id)
+        released = self.tasks.get(task.id)
+        leased = acquire_lease(released, lease)
+        handle = self.executor.launch(leased, lease)
+        self.tasks.put_authoritative(leased)
+        self._observe_worker(worker_id, handle.session_handle, task.id, lease.lease_id, alive=True)
+        self._emit(task.id, "WORKER_ADOPTED", {"worker_id": worker_id, "lease_id": lease.lease_id})
+        report.adopted.append(task.id)
+
+    def _resume_waiting(self, task: Task, report: ReconcileReport) -> None:
+        lease = task.lease
+        resumed = transition_task(task, TaskState.RUNNING, lease_id=lease.lease_id, new_lease=lease)
+        self.executor.resume(resumed, lease.worker_id, lease)
+        self.tasks.put_authoritative(resumed)
+        self._observe_worker(lease.worker_id, None, task.id, lease.lease_id, alive=True)
+        self._emit(task.id, "RESUMED", {"worker_id": lease.worker_id})
+        report.resumed.append(task.id)
+
+    # -- main pass -------------------------------------------------------------
+
+    def reconcile_once(self) -> ReconcileReport:
+        report = ReconcileReport()
+        for task in self.tasks.list():
+            if task.state is TaskState.READY:
+                self._actuate_ready(task, report)
+                continue
+
+            if task.state is TaskState.RUNNING and task.lease is not None:
+                obs = self.executor.poll(task.lease.worker_id)
+                # Fence: only a receipt echoing the authoritative lease counts.
+                if obs.receipt is not None and obs.receipt.lease_id != task.lease.lease_id:
+                    report.ignored_stale.append(obs.receipt.worker_id)
+                    obs = obs.__class__(worker_id=obs.worker_id, alive=obs.alive, receipt=None)
+                if obs.receipt is not None:
+                    self._apply_receipt(task, obs.receipt, report)
+                elif not obs.alive:
+                    self._adopt_crashed(task, report)
+                else:
+                    self._observe_worker(
+                        task.lease.worker_id, None, task.id, task.lease.lease_id, alive=True
+                    )
+                    report.heartbeats.append(task.lease.worker_id)
+                continue
+
+            if task.state is TaskState.WAITING and task.lease is not None:
+                if self.unblock is not None and self.unblock(task):
+                    self._resume_waiting(task, report)
+                continue
+
+        return report

--- a/src/agent_farm_runtime/reconciler.py
+++ b/src/agent_farm_runtime/reconciler.py
@@ -142,10 +142,14 @@ class Reconciler:
         payload = {"worker_id": worker_id, "lease_id": lease.lease_id}
         if adopting_from:
             payload["dead_worker_id"] = adopting_from
+        # 1. commit the NEW authoritative ownership FIRST, so a crash never leaves
+        #    the stale generation retired with no durable successor recorded;
+        self._commit(leased, event, payload)
+        # 2. only then retire the stale generation (fenced already by the new lease);
         if adopting_from:
             self.executor.stop(adopting_from)
-        self._commit(leased, event, payload)        # PERSIST desired state FIRST
-        handle = self.executor.launch(leased, lease)  # THEN actuate (idempotent per lease)
+        # 3. then actuate the new worker (idempotent per lease).
+        handle = self.executor.launch(leased, lease)
         self._observe(worker_id, handle.session_handle, task.id, lease.lease_id, alive=True)
         getattr(report, key).append(task.id)
 

--- a/src/agent_farm_runtime/reconciler.py
+++ b/src/agent_farm_runtime/reconciler.py
@@ -20,7 +20,6 @@ from .models import (
 from .store import FarmPaths, TaskStore, WorkerRegistry
 from .transitions import acquire_lease, rotate_lease, transition_task
 
-# States from which a worker's structured receipt drives the next state.
 _RECEIPT_TARGET = {
     ReceiptStatus.AWAITING: TaskState.WAITING,
     ReceiptStatus.SUBMITTED: TaskState.SUBMITTED,
@@ -28,32 +27,48 @@ _RECEIPT_TARGET = {
 }
 
 
-def _now() -> str:
-    return datetime.now(timezone.utc).isoformat()
+def _default_clock() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return None
 
 
 @dataclass
 class ReconcileReport:
-    launched: list[str] = field(default_factory=list)       # task ids newly actuated
-    adopted: list[str] = field(default_factory=list)        # task ids re-actuated after crash
-    advanced: list[tuple[str, str]] = field(default_factory=list)  # (task, new state)
-    resumed: list[str] = field(default_factory=list)        # WAITING->RUNNING
-    heartbeats: list[str] = field(default_factory=list)     # worker ids seen alive
-    ignored_stale: list[str] = field(default_factory=list)  # fenced-out receipts (worker ids)
+    launched: list[str] = field(default_factory=list)
+    adopted: list[str] = field(default_factory=list)
+    advanced: list[tuple[str, str]] = field(default_factory=list)
+    resumed: list[str] = field(default_factory=list)
+    heartbeats: list[str] = field(default_factory=list)
+    ignored_stale: list[str] = field(default_factory=list)
+    waiting_grace: list[str] = field(default_factory=list)  # dead-looking but within grace
 
 
 class Reconciler:
     """Serialized, idempotent control loop (INV-6).
 
-    One `reconcile_once` call is a single pass over authoritative task state; it
-    is the only thing that actuates workers. It:
-      1. actuates READY tasks (mint lease, launch worker, READY->RUNNING);
-      2. applies fenced receipts from live workers (RUNNING->WAITING/SUBMITTED/FAILED);
-      3. adopts crashed RUNNING tasks (rotate lease off the dead worker, relaunch);
-      4. resumes WAITING tasks whose unblock predicate fires;
-      5. repairs the observed Worker Registry to match Task.lease + liveness.
-    All state mutation goes through transitions/lease helpers; the registry is
-    observed-only and never authoritative.
+    Crash-consistency contract (per review):
+      * Desired authoritative state (RUNNING + lease) is PERSISTED BEFORE any
+        external actuation. If the reconciler dies between persist and launch,
+        the next pass sees a RUNNING task whose worker is absent and re-actuates
+        it after the grace window -- it never double-launches, because launch is
+        never re-issued for a lease that is only *transiently* unobserved.
+      * A lease is rotated off a worker ONLY when that worker is DURABLY dead:
+        not observed alive AND no valid receipt AND no heartbeat within
+        `grace_seconds`. A single transient liveness miss never revokes a live
+        worker's lease (INV-5).
+      * Every authoritative mutation -- state transition AND lease acquire/
+        rotate/release -- goes through the one `_commit` boundary (INV-7): a
+        durable Task Store write paired with an event.
+    Concurrency is the caller's responsibility (see locking.single_reconciler);
+    two reconcilers must not run on one farm.
     """
 
     def __init__(
@@ -62,157 +77,154 @@ class Reconciler:
         executor: WorkerExecutor,
         *,
         actor: str = "reconciler",
-        clock: Callable[[], str] = _now,
+        clock: Callable[[], datetime] = _default_clock,
         unblock: Callable[[Task], bool] | None = None,
+        grace_seconds: float = 60.0,
     ):
         self.paths = paths
         self.executor = executor
         self.actor = actor
         self.clock = clock
         self.unblock = unblock
+        self.grace_seconds = grace_seconds
         self.tasks = TaskStore(paths)
         self.registry = WorkerRegistry(paths)
         self.events = EventLog(paths.events / "log.ndjson")
 
-    # -- helpers ---------------------------------------------------------------
+    # -- boundaries ------------------------------------------------------------
+
+    def _iso(self) -> str:
+        return self.clock().isoformat()
 
     def _emit(self, task_id: str, type_: str, payload: dict) -> None:
-        self.events.append(
-            Event(
-                id=uuid.uuid4().hex,
-                task_id=task_id,
-                type=type_,
-                actor=self.actor,
-                payload=payload,
-                ts=self.clock(),
-            )
-        )
+        self.events.append(Event(
+            id=uuid.uuid4().hex, task_id=task_id, type=type_,
+            actor=self.actor, payload=payload, ts=self._iso(),
+        ))
 
-    def _mint_lease(self, worker_id: str) -> Lease:
-        return Lease(worker_id=worker_id, lease_id=uuid.uuid4().hex)
+    def _commit(self, new_task: Task, event_type: str, payload: dict) -> None:
+        """The single authoritative-mutation boundary: durable write + event.
+        Every state transition and every lease change is applied through here."""
+        self.tasks.put_authoritative(new_task)
+        self._emit(new_task.id, event_type, payload)
 
-    def _observe_worker(self, worker_id: str, handle: str | None, task_id: str, lease_id: str, alive: bool) -> None:
-        self.registry.put_observed(
-            Worker(
-                id=worker_id,
-                session_handle=handle,
-                heartbeat=self.clock(),
-                lease={"task_id": task_id, "lease_id": lease_id},
-                state=WorkerState.BUSY if alive else WorkerState.DEAD,
-            )
-        )
+    def _mint(self, task_id: str) -> tuple[str, Lease]:
+        worker_id = f"W-{task_id}-{uuid.uuid4().hex[:6]}"
+        return worker_id, Lease(worker_id=worker_id, lease_id=uuid.uuid4().hex)
 
-    # -- individual task handlers ---------------------------------------------
+    def _observe(self, worker_id: str, handle: str | None, task_id: str,
+                 lease_id: str, *, alive: bool) -> None:
+        self.registry.put_observed(Worker(
+            id=worker_id, session_handle=handle, heartbeat=self._iso(),
+            lease={"task_id": task_id, "lease_id": lease_id},
+            state=WorkerState.BUSY if alive else WorkerState.DEAD,
+        ))
 
-    def _actuate_ready(self, task: Task, report: ReconcileReport) -> None:
-        worker_id = f"W-{task.id}-{uuid.uuid4().hex[:6]}"
-        lease = self._mint_lease(worker_id)
-        leased = acquire_lease(task, lease)
-        handle = self.executor.launch(leased, lease)
-        started = transition_task(
-            leased, TaskState.RUNNING, lease_id=lease.lease_id, new_lease=lease
-        )
-        self.tasks.put_authoritative(started)
-        self._observe_worker(worker_id, handle.session_handle, task.id, lease.lease_id, alive=True)
-        self._emit(task.id, "WORKER_LAUNCHED", {"worker_id": worker_id, "lease_id": lease.lease_id})
-        report.launched.append(task.id)
+    # -- actuation (persist BEFORE launch) ------------------------------------
 
-    def _apply_receipt(self, task: Task, receipt: Receipt, report: ReconcileReport) -> bool:
-        """Apply a fenced receipt to a RUNNING task. Returns True if state changed."""
+    def _start(self, task: Task, report: ReconcileReport, *, adopting_from: str | None = None) -> None:
+        """Compose lease acquisition + RUNNING into ONE persisted mutation, then
+        actuate. Used for first start (READY->RUNNING) and adoption (rotate off a
+        dead worker + re-acquire), so no RUNNING-without-lease state is ever
+        persisted, even across a crash mid-adoption."""
+        base = task
+        if adopting_from is not None:
+            base = rotate_lease(task, dead_worker_id=adopting_from,
+                                reason=f"no heartbeat within {self.grace_seconds}s")
+        worker_id, lease = self._mint(task.id)
+        leased = acquire_lease(base, lease, metadata_patch={"launched_ts": self._iso()})
+        if base.state is TaskState.READY:
+            leased = transition_task(leased, TaskState.RUNNING,
+                                     lease_id=lease.lease_id, new_lease=lease)
+            event, key = "WORKER_LAUNCHED", "launched"
+        else:  # already RUNNING (adoption / leaseless repair)
+            event, key = ("WORKER_ADOPTED", "adopted") if adopting_from else ("WORKER_RELAUNCHED", "launched")
+        payload = {"worker_id": worker_id, "lease_id": lease.lease_id}
+        if adopting_from:
+            payload["dead_worker_id"] = adopting_from
+        if adopting_from:
+            self.executor.stop(adopting_from)
+        self._commit(leased, event, payload)        # PERSIST desired state FIRST
+        handle = self.executor.launch(leased, lease)  # THEN actuate (idempotent per lease)
+        self._observe(worker_id, handle.session_handle, task.id, lease.lease_id, alive=True)
+        getattr(report, key).append(task.id)
+
+    def _apply_receipt(self, task: Task, receipt: Receipt, report: ReconcileReport) -> None:
         if receipt.status is ReceiptStatus.RUNNING:
-            self._observe_worker(
-                receipt.worker_id, None, task.id, task.lease.lease_id, alive=True
-            )
+            self._observe(receipt.worker_id, None, task.id, task.lease.lease_id, alive=True)
             report.heartbeats.append(receipt.worker_id)
-            return False
-
+            return
         target = _RECEIPT_TARGET[receipt.status]
         patch: dict = {"last_receipt_note": receipt.note}
         if target is TaskState.WAITING:
             patch["waiting_on"] = receipt.waiting_on or "unspecified"
-        # SUBMITTED/FAILED/WAITING: keep the lease on WAITING (same worker may
-        # resume); release it on SUBMITTED/FAILED so no worker lingers as owner.
         new_lease: object = task.lease if target is TaskState.WAITING else None
-        advanced = transition_task(
-            task,
-            target,
-            lease_id=task.lease.lease_id,
-            metadata_patch=patch,
-            new_lease=new_lease,
-        )
-        self.tasks.put_authoritative(advanced)
+        advanced = transition_task(task, target, lease_id=task.lease.lease_id,
+                                   metadata_patch=patch, new_lease=new_lease)
+        self._commit(advanced, "RECEIPT_APPLIED",
+                     {"worker_id": receipt.worker_id, "status": receipt.status.value,
+                      "to": target.value})
+        # the codex worker ends its run at a wait/submit boundary: mark not-alive
         if target is not TaskState.WAITING:
             self.executor.stop(receipt.worker_id)
-            self._observe_worker(
-                receipt.worker_id, None, task.id, task.lease.lease_id, alive=False
-            )
-        else:
-            self._observe_worker(
-                receipt.worker_id, None, task.id, task.lease.lease_id, alive=True
-            )
-        self._emit(
-            task.id,
-            "RECEIPT_APPLIED",
-            {"worker_id": receipt.worker_id, "status": receipt.status.value, "to": target.value},
-        )
+        self._observe(receipt.worker_id, None, task.id, task.lease.lease_id, alive=False)
         report.advanced.append((task.id, target.value))
-        return True
 
-    def _adopt_crashed(self, task: Task, report: ReconcileReport) -> None:
-        dead = task.lease.worker_id
-        self.executor.stop(dead)  # best-effort fence of the dead generation
-        released = rotate_lease(task, dead_worker_id=dead)
-        self.tasks.put_authoritative(released)
-        self._emit(task.id, "LEASE_ROTATED", {"dead_worker_id": dead})
-        # re-actuate onto a fresh worker; state is preserved (still RUNNING)
-        worker_id = f"W-{task.id}-{uuid.uuid4().hex[:6]}"
-        lease = self._mint_lease(worker_id)
-        released = self.tasks.get(task.id)
-        leased = acquire_lease(released, lease)
-        handle = self.executor.launch(leased, lease)
-        self.tasks.put_authoritative(leased)
-        self._observe_worker(worker_id, handle.session_handle, task.id, lease.lease_id, alive=True)
-        self._emit(task.id, "WORKER_ADOPTED", {"worker_id": worker_id, "lease_id": lease.lease_id})
-        report.adopted.append(task.id)
-
-    def _resume_waiting(self, task: Task, report: ReconcileReport) -> None:
+    def _resume(self, task: Task, report: ReconcileReport) -> None:
         lease = task.lease
-        resumed = transition_task(task, TaskState.RUNNING, lease_id=lease.lease_id, new_lease=lease)
-        self.executor.resume(resumed, lease.worker_id, lease)
-        self.tasks.put_authoritative(resumed)
-        self._observe_worker(lease.worker_id, None, task.id, lease.lease_id, alive=True)
-        self._emit(task.id, "RESUMED", {"worker_id": lease.worker_id})
+        resumed = transition_task(task, TaskState.RUNNING, lease_id=lease.lease_id,
+                                  new_lease=lease, metadata_patch={"launched_ts": self._iso()})
+        self._commit(resumed, "RESUMED", {"worker_id": lease.worker_id})  # persist first
+        self.executor.resume(resumed, lease.worker_id, lease)             # then actuate
+        self._observe(lease.worker_id, None, task.id, lease.lease_id, alive=True)
         report.resumed.append(task.id)
+
+    # -- death detection (grace) ----------------------------------------------
+
+    def _durably_dead(self, task: Task, workers: dict[str, Worker]) -> bool:
+        """True only if the leased worker has been unobserved past the grace
+        window. Baseline = last heartbeat (observed) or launch time (authoritative
+        floor). A single transient miss returns False."""
+        now = self.clock()
+        w = workers.get(task.lease.worker_id)
+        baseline = _parse(w.heartbeat if w else None) or _parse(task.metadata.get("launched_ts"))
+        if baseline is None:
+            return False  # unknown age -> conservative: do not revoke
+        return (now - baseline).total_seconds() >= self.grace_seconds
 
     # -- main pass -------------------------------------------------------------
 
     def reconcile_once(self) -> ReconcileReport:
         report = ReconcileReport()
+        workers = {w.id: w for w in self.registry.list()}
         for task in self.tasks.list():
             if task.state is TaskState.READY:
-                self._actuate_ready(task, report)
+                self._start(task, report)
                 continue
 
-            if task.state is TaskState.RUNNING and task.lease is not None:
+            if task.state is TaskState.RUNNING:
+                if task.lease is None:
+                    # persisted RUNNING must carry a lease; repair by re-actuating
+                    self._start(task, report)
+                    continue
                 obs = self.executor.poll(task.lease.worker_id)
-                # Fence: only a receipt echoing the authoritative lease counts.
                 if obs.receipt is not None and obs.receipt.lease_id != task.lease.lease_id:
                     report.ignored_stale.append(obs.receipt.worker_id)
                     obs = obs.__class__(worker_id=obs.worker_id, alive=obs.alive, receipt=None)
                 if obs.receipt is not None:
                     self._apply_receipt(task, obs.receipt, report)
-                elif not obs.alive:
-                    self._adopt_crashed(task, report)
-                else:
-                    self._observe_worker(
-                        task.lease.worker_id, None, task.id, task.lease.lease_id, alive=True
-                    )
+                elif obs.alive:
+                    self._observe(task.lease.worker_id, None, task.id, task.lease.lease_id, alive=True)
                     report.heartbeats.append(task.lease.worker_id)
+                elif self._durably_dead(task, workers):
+                    self._start(task, report, adopting_from=task.lease.worker_id)
+                else:
+                    report.waiting_grace.append(task.id)  # transient miss: wait, do not revoke
                 continue
 
             if task.state is TaskState.WAITING and task.lease is not None:
                 if self.unblock is not None and self.unblock(task):
-                    self._resume_waiting(task, report)
+                    self._resume(task, report)
                 continue
 
         return report

--- a/src/agent_farm_runtime/transitions.py
+++ b/src/agent_farm_runtime/transitions.py
@@ -79,3 +79,46 @@ def transition_task(
 
     lease = task.lease if new_lease is ... else new_lease
     return replace(task, state=target, metadata=metadata, lease=lease)  # type: ignore[arg-type]
+
+
+class LeaseError(ValueError):
+    pass
+
+
+def acquire_lease(task: Task, new_lease: Lease) -> Task:
+    """Grant execution ownership to a task that has none (adoption / first start).
+
+    A lease is granted only when the task currently holds no lease. This is the
+    normal READY->RUNNING actuation path and the re-actuation path after a lease
+    has been released by rotation off a dead worker.
+    """
+    if task.lease is not None:
+        raise LeaseError(
+            f"{task.id} already leased to {task.lease.worker_id}; "
+            "rotate off the dead holder before re-acquiring"
+        )
+    return replace(task, lease=new_lease)
+
+
+def rotate_lease(task: Task, *, dead_worker_id: str) -> Task:
+    """Release a lease held by a worker the reconciler has PROVEN dead/absent.
+
+    This is the crash-adoption primitive: it makes "task state is durable,
+    workers are disposable" real. It is a lease mutation, not a state
+    transition, so INV-7 (transitions are the only state mutation) is untouched;
+    the task's state is preserved. INV-5 (single valid executor) is preserved
+    because the caller must pass the id of the CURRENT lease holder and must have
+    already established that that worker is dead/absent — a lease can never be
+    rotated away from a live worker, so ownership is never double-granted.
+
+    Beyond frozen V2_DESIGN v0.2 (which stopped before actuation); intended for
+    ratification into v0.3 once canary evidence confirms it.
+    """
+    if task.lease is None:
+        raise LeaseError(f"{task.id} holds no lease to rotate")
+    if task.lease.worker_id != dead_worker_id:
+        raise LeaseError(
+            f"refusing to rotate lease: current holder is {task.lease.worker_id}, "
+            f"not {dead_worker_id} (never rotate away from a possibly-live worker)"
+        )
+    return replace(task, lease=None)

--- a/src/agent_farm_runtime/transitions.py
+++ b/src/agent_farm_runtime/transitions.py
@@ -85,7 +85,22 @@ class LeaseError(ValueError):
     pass
 
 
-def acquire_lease(task: Task, new_lease: Lease) -> Task:
+# Lease ownership is authoritative Task state. acquire/rotate/release below are
+# authoritative Task mutations, NOT exempt from INV-7: like state transitions,
+# each returns a new Task that the caller MUST commit through the single durable
+# store boundary (see Reconciler._commit), paired with an event. They are kept as
+# separate pure validators only because the legality rules differ from the state
+# graph's; the persistence boundary is the same one transitions go through.
+
+
+def with_metadata(task: Task, patch: dict[str, Any]) -> Task:
+    """Authoritative metadata-only mutation (e.g. launched_ts). Commit like any other."""
+    meta = dict(task.metadata)
+    meta.update(patch)
+    return replace(task, metadata=meta)
+
+
+def acquire_lease(task: Task, new_lease: Lease, *, metadata_patch: dict[str, Any] | None = None) -> Task:
     """Grant execution ownership to a task that has none (adoption / first start).
 
     A lease is granted only when the task currently holds no lease. This is the
@@ -97,23 +112,25 @@ def acquire_lease(task: Task, new_lease: Lease) -> Task:
             f"{task.id} already leased to {task.lease.worker_id}; "
             "rotate off the dead holder before re-acquiring"
         )
-    return replace(task, lease=new_lease)
+    meta = dict(task.metadata)
+    if metadata_patch:
+        meta.update(metadata_patch)
+    return replace(task, lease=new_lease, metadata=meta)
 
 
-def rotate_lease(task: Task, *, dead_worker_id: str) -> Task:
-    """Release a lease held by a worker the reconciler has PROVEN dead/absent.
+def rotate_lease(task: Task, *, dead_worker_id: str, reason: str) -> Task:
+    """Release a lease from a worker the reconciler has established is DEAD.
 
-    This is the crash-adoption primitive: it makes "task state is durable,
-    workers are disposable" real. It is a lease mutation, not a state
-    transition, so INV-7 (transitions are the only state mutation) is untouched;
-    the task's state is preserved. INV-5 (single valid executor) is preserved
-    because the caller must pass the id of the CURRENT lease holder and must have
-    already established that that worker is dead/absent — a lease can never be
-    rotated away from a live worker, so ownership is never double-granted.
-
-    Beyond frozen V2_DESIGN v0.2 (which stopped before actuation); intended for
-    ratification into v0.3 once canary evidence confirms it.
+    The crash-adoption primitive that makes "task state is durable, workers are
+    disposable" real. INV-5 (single valid executor) is preserved because the
+    caller must pass the id of the CURRENT lease holder AND must supply a `reason`
+    documenting how death was established (e.g. no heartbeat within the grace
+    window) — a lease must never be rotated on a single transient liveness miss,
+    which would revoke a live worker's ownership. See the reconciler's grace
+    policy for the death criterion.
     """
+    if not reason:
+        raise LeaseError("rotate_lease requires a reason establishing death")
     if task.lease is None:
         raise LeaseError(f"{task.id} holds no lease to rotate")
     if task.lease.worker_id != dead_worker_id:

--- a/tests/test_codex_tmux.py
+++ b/tests/test_codex_tmux.py
@@ -86,7 +86,7 @@ def test_launch_writes_scripts_and_sends_keys(tmp_path):
     assert "RUNTIME RECEIPT PROTOCOL" in launch          # receipt protocol appended
     # tmux: created the window and sent the launch command
     assert any("bash" in s and ".farm_launch_" in s for s in rec.sent())
-    assert handle.session_handle == "farm2:A"
+    assert handle.session_handle == "farm2:W-1"   # pane identity is the worker id
     # state persisted so poll/resume can find the worker later
     assert (rt / "codex_workers" / "W-1.json").exists()
 
@@ -189,6 +189,24 @@ def test_resume_and_stop_never_do_window_surgery(tmp_path):
     # the crash-lesson invariant: the executor never kills or moves windows
     for c in rec.calls:
         assert "kill-window" not in c and "kill-session" not in c and "move-window" not in c
+
+
+def test_resume_refreshes_worker_pid_identity_like_launch(tmp_path):
+    """The resume bug fix: resume must record THIS invocation's (pid,starttime) to
+    the same pid_file poll() reads, exactly as launch does -- otherwise liveness
+    points at the resumed worker's dead original."""
+    rt = tmp_path / "rt"; rt.mkdir()
+    ws = tmp_path / "ws"; ws.mkdir()
+    ex = CodexTmuxExecutor(rt, run=TmuxRecorder())
+    task = _task(ws)
+    ex.launch(task, Lease("W-1", "L1"))
+    (ws / ".session_id_W-1").write_text("01a00000-0000-7000-8000-000000000000")
+    ex.resume(task, "W-1", Lease("W-1", "L1"))
+    resume = next(ws.glob(".farm_resume_*.sh")).read_text()
+    pid_file = str(rt / "codex_workers" / "W-1.pid")
+    assert "$_CPID $_ST" in resume            # records pid+starttime, like launch
+    assert pid_file in resume                 # ...into the SAME pid_file poll() reads
+    assert 'resume "$SID"' in resume          # and it is a resume, not a fresh session
 
 
 # --- PR review fix: worker-specific liveness (not workspace-level pgrep) -----

--- a/tests/test_codex_tmux.py
+++ b/tests/test_codex_tmux.py
@@ -95,6 +95,20 @@ def test_defaults_to_a_separate_session_never_touches_live_farm(tmp_path):
     assert all(t == "farm2" or t.startswith("farm2:") for t in rec.tmux_targets())
 
 
+def test_dedicated_tmux_socket_isolates_from_live_farm(tmp_path):
+    rt = tmp_path / "runtime"; rt.mkdir()
+    ws = tmp_path / "ws"; ws.mkdir()
+    rec = TmuxRecorder()
+    ex = CodexTmuxExecutor(rt, session="farm2", tmux_socket="canary", run=rec)
+    ex.launch(_task(ws), Lease("W-1", "L1"))
+    # every tmux call must go to the dedicated server (-L canary): a crash of the
+    # canary server cannot take down the live farm on the default server
+    tmux_calls = [c for c in rec.calls if c and c[0] == "tmux"]
+    assert tmux_calls
+    for c in tmux_calls:
+        assert c[1:3] == ["-L", "canary"], c
+
+
 def test_poll_reads_fenced_receipt(tmp_path):
     rt = tmp_path / "runtime"; rt.mkdir()
     ws = tmp_path / "ws"; ws.mkdir()

--- a/tests/test_codex_tmux.py
+++ b/tests/test_codex_tmux.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from agent_farm_runtime.adapters.codex import CodexTmuxExecutor
+from agent_farm_runtime.doctor import run_doctor
+from agent_farm_runtime.models import Lease, Receipt, ReceiptStatus, Task, TaskState
+from agent_farm_runtime.reconciler import Reconciler
+from agent_farm_runtime.store import FarmPaths, TaskStore
+
+
+class TmuxRecorder:
+    """Fake `tmux`/subprocess runner that models just enough tmux state."""
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+        self._session = False
+        self._windows: list[str] = []
+
+    def __call__(self, cmd: list[str]) -> subprocess.CompletedProcess:
+        self.calls.append(cmd)
+        if cmd[:2] == ["tmux", "has-session"]:
+            return subprocess.CompletedProcess(cmd, 0 if self._session else 1, "", "")
+        if cmd[:2] == ["tmux", "list-windows"]:
+            return subprocess.CompletedProcess(cmd, 0, "\n".join(self._windows), "")
+        if cmd[:2] == ["tmux", "new-session"]:
+            self._session = True
+            self._windows.append(cmd[cmd.index("-n") + 1])
+        if cmd[:2] == ["tmux", "new-window"]:
+            self._windows.append(cmd[cmd.index("-n") + 1])
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    def sent(self) -> list[str]:
+        return [c[c.index("-t") + 2] for c in self.calls
+                if c[:2] == ["tmux", "send-keys"] and c[-1] == "Enter"]
+
+    def tmux_targets(self) -> list[str]:
+        out = []
+        for c in self.calls:
+            if "-t" in c:
+                out.append(c[c.index("-t") + 1])
+            if "-s" in c:
+                out.append(c[c.index("-s") + 1])
+        return out
+
+
+def _task(ws: Path, tid="T-1", label="A") -> Task:
+    return Task(
+        id=tid, objective="o", deliverable="d", acceptance="a",
+        metadata={"workspace": str(ws), "brief": "You are agent A. Do the thing.",
+                  "agent_label": label},
+    )
+
+
+def _paths(tmp: Path) -> FarmPaths:
+    p = FarmPaths(tmp / ".farm")
+    p.ensure()
+    return p
+
+
+def test_launch_writes_scripts_and_sends_keys(tmp_path):
+    ws = tmp_path / "ws"; ws.mkdir()
+    rt = tmp_path / ".farm" / "runtime"; rt.mkdir(parents=True)
+    rec = TmuxRecorder()
+    ex = CodexTmuxExecutor(rt, run=rec)
+    lease = Lease("W-1", "LEASE-XYZ")
+
+    handle = ex.launch(_task(ws), lease)
+
+    # helper + launch script land in the workspace
+    assert (ws / ".farm_receipt.py").exists()
+    launch = next(ws.glob(".farm_launch_*.sh")).read_text()
+    assert "cd " in launch and str(ws.resolve()) in launch
+    assert "codex exec --skip-git-repo-check --sandbox danger-full-access" in launch
+    assert "FARM_LEASE_ID=LEASE-XYZ" in launch          # lease is wired in
+    assert "You are agent A. Do the thing." in launch    # brief carried
+    assert "RUNTIME RECEIPT PROTOCOL" in launch          # receipt protocol appended
+    # tmux: created the window and sent the launch command
+    assert any("bash" in s and ".farm_launch_" in s for s in rec.sent())
+    assert handle.session_handle == "farm2:A"
+    # state persisted so poll/resume can find the worker later
+    assert (rt / "codex_workers" / "W-1.json").exists()
+
+
+def test_defaults_to_a_separate_session_never_touches_live_farm(tmp_path):
+    rt = tmp_path / "runtime"; rt.mkdir()
+    ws = tmp_path / "ws"; ws.mkdir()
+    rec = TmuxRecorder()
+    ex = CodexTmuxExecutor(rt, run=rec)          # default session
+    ex.launch(_task(ws), Lease("W-1", "L1"))
+    # safety invariant: canary must never target the live `farm` session
+    assert "farm" not in rec.tmux_targets()
+    assert all(t == "farm2" or t.startswith("farm2:") for t in rec.tmux_targets())
+
+
+def test_poll_reads_fenced_receipt(tmp_path):
+    rt = tmp_path / "runtime"; rt.mkdir()
+    ws = tmp_path / "ws"; ws.mkdir()
+    alive = {"v": True}
+    ex = CodexTmuxExecutor(rt, run=TmuxRecorder(), is_alive=lambda w: alive["v"])
+    ex.launch(_task(ws), Lease("W-1", "L1"))
+    rp = rt / "receipts" / "W-1.json"
+    rp.write_text(json.dumps(Receipt("W-1", "T-1", "L1", ReceiptStatus.AWAITING,
+                                     ts="t", waiting_on="job:5").to_dict()))
+    obs = ex.poll("W-1")
+    assert obs.alive is True
+    assert obs.receipt is not None and obs.receipt.status is ReceiptStatus.AWAITING
+    alive["v"] = False
+    assert ex.poll("W-1").alive is False
+
+
+def test_reconciler_drives_codex_executor_end_to_end(tmp_path):
+    paths = _paths(tmp_path)
+    ws = tmp_path / "ws"; ws.mkdir()
+    TaskStore(paths).create(_task(ws))
+    alive = {"v": True}
+    ex = CodexTmuxExecutor(paths.runtime, run=TmuxRecorder(), is_alive=lambda w: alive["v"])
+    rec = Reconciler(paths, ex)
+
+    rec.reconcile_once()                                  # READY -> RUNNING (launch)
+    t = TaskStore(paths).get("T-1")
+    assert t.state is TaskState.RUNNING and t.lease is not None
+
+    # simulate the codex agent finishing and writing a fenced SUBMITTED receipt
+    rp = paths.runtime / "receipts" / f"{t.lease.worker_id}.json"
+    rp.write_text(json.dumps(Receipt(t.lease.worker_id, "T-1", t.lease.lease_id,
+                                     ReceiptStatus.SUBMITTED, ts="t").to_dict()))
+    alive["v"] = False
+
+    rec.reconcile_once()                                  # apply receipt -> SUBMITTED
+    assert TaskStore(paths).get("T-1").state is TaskState.SUBMITTED
+    assert not any(c.level == "FAIL" for c in run_doctor(paths))
+
+
+def test_stale_receipt_from_old_generation_is_fenced(tmp_path):
+    paths = _paths(tmp_path)
+    ws = tmp_path / "ws"; ws.mkdir()
+    TaskStore(paths).create(_task(ws))
+    ex = CodexTmuxExecutor(paths.runtime, run=TmuxRecorder(), is_alive=lambda w: True)
+    rec = Reconciler(paths, ex)
+    rec.reconcile_once()
+    t = TaskStore(paths).get("T-1")
+    rp = paths.runtime / "receipts" / f"{t.lease.worker_id}.json"
+    # a receipt echoing the WRONG lease id must not advance the task
+    rp.write_text(json.dumps(Receipt(t.lease.worker_id, "T-1", "STALE",
+                                     ReceiptStatus.SUBMITTED, ts="t").to_dict()))
+    report = rec.reconcile_once()
+    assert report.ignored_stale == [t.lease.worker_id]
+    assert TaskStore(paths).get("T-1").state is TaskState.RUNNING
+
+
+def test_resume_and_stop_never_do_window_surgery(tmp_path):
+    rt = tmp_path / "runtime"; rt.mkdir()
+    ws = tmp_path / "ws"; ws.mkdir()
+    rec = TmuxRecorder()
+    ex = CodexTmuxExecutor(rt, run=rec)
+    task = _task(ws)
+    lease = Lease("W-1", "L1")
+    ex.launch(task, lease)
+    # write a session id so resume takes the resume path (not fresh launch)
+    (ws / ".session_id_W-1").write_text("dead-beef-0000-0000-0000-000000000000")
+    ex.resume(task, "W-1", lease)
+    resume = next(ws.glob(".farm_resume_*.sh")).read_text()
+    assert "codex exec --skip-git-repo-check --sandbox danger-full-access resume" in resume
+    ex.stop("W-1")
+    # the crash-lesson invariant: the executor never kills or moves windows
+    for c in rec.calls:
+        assert "kill-window" not in c and "kill-session" not in c and "move-window" not in c

--- a/tests/test_codex_tmux.py
+++ b/tests/test_codex_tmux.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
-from agent_farm_runtime.adapters.codex import CodexTmuxExecutor
+from agent_farm_runtime.adapters.codex import (
+    CodexClusterConfig,
+    CodexTmuxExecutor,
+    render_launch_script,
+)
 from agent_farm_runtime.doctor import run_doctor
 from agent_farm_runtime.models import Lease, Receipt, ReceiptStatus, Task, TaskState
+from agent_farm_runtime.procutil import proc_starttime
 from agent_farm_runtime.reconciler import Reconciler
 from agent_farm_runtime.store import FarmPaths, TaskStore
 
@@ -182,3 +189,40 @@ def test_resume_and_stop_never_do_window_surgery(tmp_path):
     # the crash-lesson invariant: the executor never kills or moves windows
     for c in rec.calls:
         assert "kill-window" not in c and "kill-session" not in c and "move-window" not in c
+
+
+# --- PR review fix: worker-specific liveness (not workspace-level pgrep) -----
+
+
+def test_two_workers_in_one_workspace_are_never_confused(tmp_path):
+    """The named regression: two workers sharing a workspace must be judged
+    independently by per-worker pid identity, not by any codex whose cwd matches
+    the workspace (which cannot tell them apart)."""
+    rt = tmp_path / "rt"; rt.mkdir()
+    ws = tmp_path / "ws"; ws.mkdir()
+    ex = CodexTmuxExecutor(rt, run=TmuxRecorder())  # DEFAULT pid-identity liveness
+    ex.launch(_task(ws, tid="T-a", label="A"), Lease("W-A", "LA"))
+    ex.launch(_task(ws, tid="T-b", label="B"), Lease("W-B", "LB"))
+    # same workspace, two workers: A is alive (this process), B is dead
+    (rt / "codex_workers" / "W-A.pid").write_text(f"{os.getpid()} {proc_starttime(os.getpid())}")
+    (rt / "codex_workers" / "W-B.pid").write_text("2147480000 1")  # nonexistent pid
+    assert ex.poll("W-A").alive is True
+    assert ex.poll("W-B").alive is False   # not fooled by A being live in the same ws
+
+
+def test_launch_records_pid_identity_and_scopes_session_id_to_that_pid(tmp_path):
+    s = render_launch_script(
+        cfg=CodexClusterConfig(), workspace="/ws", worker_id="W1", task_id="T1",
+        lease_id="L1", receipt_path="/r.json", brief="b", log_name="l.log",
+        sid_path="/ws/.sid", pid_file="/rt/W1.pid",
+    )
+    assert "$_CPID $_ST" in s               # (pid, starttime) identity recorded
+    assert "session id:" in s               # session id from THIS worker's own log
+    assert "l.log" in s                     # ...which is this worker's per-worker log
+    assert "ls -t" not in s                 # no race-prone "newest rollout" heuristic
+    assert "/proc/$_CPID/fd" not in s       # not the (unreliable) open-fd approach
+    if shutil.which("bash"):
+        p = Path("/tmp/_farm_codex_render_check.sh")
+        p.write_text(s)
+        assert subprocess.run(["bash", "-n", str(p)]).returncode == 0
+        p.unlink()

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
 
@@ -10,6 +12,7 @@ import pytest
 from agent_farm_runtime.adapters.fake import FakeExecutor
 from agent_farm_runtime.adapters.local_process import LocalProcessExecutor
 from agent_farm_runtime.doctor import run_doctor
+from agent_farm_runtime.locking import ReconcilerBusy, single_reconciler
 from agent_farm_runtime.models import Receipt, ReceiptStatus, Task, TaskState
 from agent_farm_runtime.reconciler import Reconciler
 from agent_farm_runtime.store import FarmPaths, TaskStore
@@ -19,6 +22,26 @@ from agent_farm_runtime.transitions import (
     acquire_lease,
     rotate_lease,
 )
+
+
+class _Clock:
+    """Manual clock for deterministic grace-window tests."""
+
+    def __init__(self, start: float = 1_000.0):
+        self.t = start
+
+    def __call__(self) -> datetime:
+        return datetime.fromtimestamp(self.t, tz=timezone.utc)
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _events(paths: FarmPaths) -> list[dict]:
+    log = paths.events / "log.ndjson"
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
 
 
 def _paths(tmp_path: Path) -> FarmPaths:
@@ -55,8 +78,11 @@ def test_rotate_lease_refuses_wrong_holder():
     task = acquire_lease(_ready_task(), Lease("W1", "L1"))
     # never rotate a lease off anyone but the current (proven-dead) holder
     with pytest.raises(LeaseError):
-        rotate_lease(task, dead_worker_id="W2")
-    released = rotate_lease(task, dead_worker_id="W1")
+        rotate_lease(task, dead_worker_id="W2", reason="dead")
+    # and a rotation must document how death was established
+    with pytest.raises(LeaseError):
+        rotate_lease(task, dead_worker_id="W1", reason="")
+    released = rotate_lease(task, dead_worker_id="W1", reason="no heartbeat within grace")
     assert released.lease is None
 
 
@@ -143,7 +169,7 @@ def test_adopts_crashed_worker(tmp_path):
     paths = _paths(tmp_path)
     TaskStore(paths).create(_ready_task())
     ex = FakeExecutor()
-    rec = Reconciler(paths, ex)
+    rec = Reconciler(paths, ex, grace_seconds=0)  # adopt as soon as death is seen
     rec.reconcile_once()
     first = TaskStore(paths).get("T-1").lease
     assert first is not None
@@ -235,7 +261,7 @@ def test_local_process_executor_adopts_dead_process(tmp_path):
     paths = _paths(tmp_path)
     TaskStore(paths).create(_ready_task(command="exit 7"))  # dies, writes no receipt
     ex = LocalProcessExecutor(paths.runtime)
-    rec = Reconciler(paths, ex)
+    rec = Reconciler(paths, ex, grace_seconds=0)
 
     rec.reconcile_once()
     first = TaskStore(paths).get("T-1").lease
@@ -247,3 +273,91 @@ def test_local_process_executor_adopts_dead_process(tmp_path):
     assert t.state is TaskState.RUNNING
     assert t.lease.worker_id != first.worker_id
     _no_fail(paths)
+
+
+# --- crash-consistency fixes (PR review) ------------------------------------
+
+
+def test_persists_running_and_lease_before_external_launch(tmp_path):
+    """INV: desired authoritative state is committed BEFORE actuation, so a crash
+    between persist and launch cannot double-actuate."""
+    paths = _paths(tmp_path)
+    store = TaskStore(paths)
+    store.create(_ready_task())
+
+    seen = {}
+
+    class PeekExecutor(FakeExecutor):
+        def launch(self, task, lease):
+            t = store.get(task.id)                 # what is durably persisted at launch time?
+            seen["state"] = t.state
+            seen["lease_id"] = t.lease.lease_id if t.lease else None
+            return super().launch(task, lease)
+
+    Reconciler(paths, PeekExecutor()).reconcile_once()
+    assert seen["state"] is TaskState.RUNNING
+    assert seen["lease_id"] == store.get("T-1").lease.lease_id
+
+
+def test_grace_prevents_premature_adoption(tmp_path):
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+    clk = _Clock()
+    rec = Reconciler(paths, ex, clock=clk, grace_seconds=30)
+    rec.reconcile_once()                              # launch at t0
+    lease = TaskStore(paths).get("T-1").lease
+    ex.kill(lease.worker_id)                          # looks dead...
+
+    clk.advance(10)                                   # ...but only 10s < 30s grace
+    rep = rec.reconcile_once()
+    assert rep.adopted == [] and rep.waiting_grace == ["T-1"]
+    still = TaskStore(paths).get("T-1")
+    assert still.state is TaskState.RUNNING
+    assert still.lease.worker_id == lease.worker_id   # live worker's lease NOT revoked
+
+    clk.advance(25)                                   # now 35s > grace -> durably dead
+    rep = rec.reconcile_once()
+    assert rep.adopted == ["T-1"]
+    assert TaskStore(paths).get("T-1").lease.worker_id != lease.worker_id
+    _no_fail(paths)
+
+
+def test_adoption_is_atomic_and_audited(tmp_path):
+    """Lease rotation goes through the authoritative boundary: WORKER_ADOPTED
+    names the dead worker, and no RUNNING-without-lease is ever persisted."""
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+    rec = Reconciler(paths, ex, grace_seconds=0)
+    rec.reconcile_once()
+    first = TaskStore(paths).get("T-1").lease
+    ex.kill(first.worker_id)
+    rec.reconcile_once()
+
+    adopted = [e for e in _events(paths) if e["type"] == "WORKER_ADOPTED"]
+    assert adopted and adopted[0]["payload"]["dead_worker_id"] == first.worker_id
+    _no_fail(paths)  # doctor never saw RUNNING without an authoritative lease
+
+
+def test_local_process_launch_is_idempotent_per_lease(tmp_path):
+    paths = _paths(tmp_path)
+    ex = LocalProcessExecutor(paths.runtime)
+    task = _ready_task(command="sleep 5")
+    lease = Lease("W-idem", "L-idem")
+    h1 = ex.launch(task, lease)
+    h2 = ex.launch(task, lease)                       # already alive -> no second process
+    assert h1.session_handle == h2.session_handle
+    ex.stop("W-idem")
+
+
+def test_single_reconciler_lock_is_exclusive(tmp_path):
+    rt = tmp_path / "rt"
+    rt.mkdir()
+    with single_reconciler(rt):
+        with pytest.raises(ReconcilerBusy):
+            with single_reconciler(rt):
+                pass
+    # released -> acquirable again
+    with single_reconciler(rt):
+        pass

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -419,6 +419,40 @@ def test_new_ownership_committed_before_stale_worker_stopped(tmp_path):
     assert stops[-1][1] != first.lease_id
 
 
+def test_resumed_worker_survives_grace_without_adoption(tmp_path):
+    """After a WAITING->RUNNING resume, the resumed worker's refreshed liveness
+    must keep it alive past the grace window -- no false adoption."""
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+    clk = _Clock()
+    rec = Reconciler(paths, ex, clock=clk, grace_seconds=30,
+                     unblock=lambda t: t.metadata.get("waiting_on") == "job:1")
+    rec.reconcile_once()                                   # launch
+    lease = TaskStore(paths).get("T-1").lease
+    wid = lease.worker_id
+
+    # worker reaches a wait boundary and its process ENDS
+    ex.set_receipt(Receipt(wid, "T-1", lease.lease_id, ReceiptStatus.AWAITING,
+                           ts="t", waiting_on="job:1"))
+    rec.reconcile_once()
+    assert TaskStore(paths).get("T-1").state is TaskState.WAITING
+    ex.clear_receipt(wid)
+    ex.kill(wid)                                           # the awaiting worker exited
+
+    # unblock fires -> resume must refresh liveness (the bug: it didn't)
+    rep = rec.reconcile_once()
+    assert rep.resumed == ["T-1"]
+    assert TaskStore(paths).get("T-1").state is TaskState.RUNNING
+
+    clk.advance(10_000)                                    # far past grace
+    rep = rec.reconcile_once()
+    assert rep.adopted == []                               # NOT falsely adopted
+    assert wid in rep.heartbeats
+    assert TaskStore(paths).get("T-1").lease.worker_id == wid
+    _no_fail(paths)
+
+
 def test_pid_identity_rejects_recycled_pid(tmp_path):
     me = os.getpid()
     st = proc_starttime(me)

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from agent_farm_runtime.adapters.fake import FakeExecutor
+from agent_farm_runtime.adapters.local_process import LocalProcessExecutor
+from agent_farm_runtime.doctor import run_doctor
+from agent_farm_runtime.models import Receipt, ReceiptStatus, Task, TaskState
+from agent_farm_runtime.reconciler import Reconciler
+from agent_farm_runtime.store import FarmPaths, TaskStore
+from agent_farm_runtime.transitions import (
+    LeaseError,
+    Lease,
+    acquire_lease,
+    rotate_lease,
+)
+
+
+def _paths(tmp_path: Path) -> FarmPaths:
+    paths = FarmPaths(tmp_path / ".farm")
+    paths.ensure()
+    return paths
+
+
+def _ready_task(tid: str = "T-1", **meta) -> Task:
+    return Task(
+        id=tid,
+        objective="obj",
+        deliverable="del",
+        acceptance="acc",
+        metadata=dict(meta),
+    )
+
+
+def _no_fail(paths: FarmPaths) -> None:
+    assert not any(c.level == "FAIL" for c in run_doctor(paths))
+
+
+# --- lease helper guards (the crash-adoption primitive) ---------------------
+
+
+def test_acquire_lease_rejects_double_grant():
+    task = _ready_task()
+    leased = acquire_lease(task, Lease("W1", "L1"))
+    with pytest.raises(LeaseError):
+        acquire_lease(leased, Lease("W2", "L2"))
+
+
+def test_rotate_lease_refuses_wrong_holder():
+    task = acquire_lease(_ready_task(), Lease("W1", "L1"))
+    # never rotate a lease off anyone but the current (proven-dead) holder
+    with pytest.raises(LeaseError):
+        rotate_lease(task, dead_worker_id="W2")
+    released = rotate_lease(task, dead_worker_id="W1")
+    assert released.lease is None
+
+
+# --- full actuation loop with the fake executor -----------------------------
+
+
+def test_actuates_ready_task(tmp_path):
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+    rep = Reconciler(paths, ex).reconcile_once()
+
+    assert rep.launched == ["T-1"]
+    task = TaskStore(paths).get("T-1")
+    assert task.state is TaskState.RUNNING
+    assert task.lease is not None
+    assert ex.launched and ex.launched[0][1] == "T-1"
+    _no_fail(paths)
+
+
+def test_happy_path_running_waiting_resume_submitted(tmp_path):
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+
+    unblocked = {"go": False}
+    rec = Reconciler(paths, ex, unblock=lambda t: unblocked["go"])
+    rec.reconcile_once()  # -> RUNNING
+    lease = TaskStore(paths).get("T-1").lease
+    wid = lease.worker_id
+
+    # worker reports it hit a wait boundary
+    ex.set_receipt(Receipt(wid, "T-1", lease.lease_id, ReceiptStatus.AWAITING,
+                           ts="t", waiting_on="job:12345"))
+    rec.reconcile_once()
+    t = TaskStore(paths).get("T-1")
+    assert t.state is TaskState.WAITING
+    assert t.metadata["waiting_on"] == "job:12345"
+    assert t.lease is not None  # lease kept across WAITING
+    _no_fail(paths)
+
+    # still blocked -> reconcile is a no-op
+    ex.clear_receipt(wid)
+    rec.reconcile_once()
+    assert TaskStore(paths).get("T-1").state is TaskState.WAITING
+
+    # unblock fires -> resumed to RUNNING, same lease/worker
+    unblocked["go"] = True
+    rep = rec.reconcile_once()
+    assert rep.resumed == ["T-1"]
+    t = TaskStore(paths).get("T-1")
+    assert t.state is TaskState.RUNNING and t.lease.lease_id == lease.lease_id
+    assert wid in ex.resumed
+
+    # worker submits the final deliverable
+    ex.set_receipt(Receipt(wid, "T-1", lease.lease_id, ReceiptStatus.SUBMITTED, ts="t"))
+    rec.reconcile_once()
+    t = TaskStore(paths).get("T-1")
+    assert t.state is TaskState.SUBMITTED
+    assert t.lease is None  # ownership released on submission
+    assert wid in ex.stopped
+    _no_fail(paths)
+
+
+def test_stale_receipt_is_fenced_out(tmp_path):
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+    rec = Reconciler(paths, ex)
+    rec.reconcile_once()
+    lease = TaskStore(paths).get("T-1").lease
+
+    # a superseded worker generation emits a SUBMITTED with the WRONG lease id
+    ex.set_receipt(Receipt(lease.worker_id, "T-1", "STALE-LEASE",
+                           ReceiptStatus.SUBMITTED, ts="t"))
+    rep = rec.reconcile_once()
+
+    assert rep.ignored_stale == [lease.worker_id]
+    assert TaskStore(paths).get("T-1").state is TaskState.RUNNING  # not advanced
+    _no_fail(paths)
+
+
+def test_adopts_crashed_worker(tmp_path):
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+    rec = Reconciler(paths, ex)
+    rec.reconcile_once()
+    first = TaskStore(paths).get("T-1").lease
+    assert first is not None
+
+    ex.kill(first.worker_id)  # worker dies mid-flight, no receipt
+    rep = rec.reconcile_once()
+
+    assert rep.adopted == ["T-1"]
+    t = TaskStore(paths).get("T-1")
+    assert t.state is TaskState.RUNNING            # state survived the crash
+    assert t.lease is not None
+    assert t.lease.worker_id != first.worker_id    # new worker generation
+    assert t.lease.lease_id != first.lease_id
+    assert len(ex.launched) == 2                   # relaunched
+    assert first.worker_id in ex.stopped           # dead gen fenced
+    _no_fail(paths)                                 # exactly one authoritative lease
+
+
+# --- master acceptance is NOT a worker/reconciler action --------------------
+
+
+def test_submitted_requires_master_acceptance_for_done(tmp_path):
+    from agent_farm_runtime.transitions import transition_task
+
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task())
+    ex = FakeExecutor()
+    rec = Reconciler(paths, ex)
+    rec.reconcile_once()
+    lease = TaskStore(paths).get("T-1").lease
+    ex.set_receipt(Receipt(lease.worker_id, "T-1", lease.lease_id,
+                           ReceiptStatus.SUBMITTED, ts="t"))
+    rec.reconcile_once()
+    submitted = TaskStore(paths).get("T-1")
+
+    # a worker can never drive DONE: DONE needs recorded acceptance
+    from agent_farm_runtime.transitions import TransitionError
+    with pytest.raises(TransitionError):
+        transition_task(submitted, TaskState.DONE, acceptance_recorded=False)
+
+    accepted = transition_task(
+        submitted, TaskState.DONE, acceptance_recorded=True,
+        metadata_patch={"acceptance_receipt": "sha256:abc"},
+    )
+    TaskStore(paths).put_authoritative(accepted)
+    assert TaskStore(paths).get("T-1").state is TaskState.DONE
+    _no_fail(paths)
+
+
+# --- real OS subprocess end-to-end (non-fake executor) ----------------------
+
+
+def _wait(pred, timeout=15.0, dt=0.05):
+    end = time.time() + timeout
+    while time.time() < end:
+        if pred():
+            return True
+        time.sleep(dt)
+    return False
+
+
+def test_local_process_executor_submits(tmp_path):
+    paths = _paths(tmp_path)
+    worker_py = tmp_path / "worker.py"
+    worker_py.write_text(dedent("""
+        import json, os
+        r = {"worker_id": os.environ["FARM_WORKER_ID"],
+             "task_id": os.environ["FARM_TASK_ID"],
+             "lease_id": os.environ["FARM_LEASE_ID"],
+             "status": "SUBMITTED", "ts": "t", "note": "real process done",
+             "waiting_on": None}
+        with open(os.environ["FARM_RECEIPT_PATH"], "w") as fh:
+            json.dump(r, fh)
+    """))
+    TaskStore(paths).create(_ready_task(command=f"{sys.executable} {worker_py}"))
+    ex = LocalProcessExecutor(paths.runtime)
+    rec = Reconciler(paths, ex)
+
+    rec.reconcile_once()  # launches a real subprocess
+    wid = TaskStore(paths).get("T-1").lease.worker_id
+    assert _wait(lambda: ex.poll(wid).receipt is not None), "worker never wrote receipt"
+
+    rec.reconcile_once()  # picks up the fenced SUBMITTED receipt
+    assert TaskStore(paths).get("T-1").state is TaskState.SUBMITTED
+    _no_fail(paths)
+
+
+def test_local_process_executor_adopts_dead_process(tmp_path):
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready_task(command="exit 7"))  # dies, writes no receipt
+    ex = LocalProcessExecutor(paths.runtime)
+    rec = Reconciler(paths, ex)
+
+    rec.reconcile_once()
+    first = TaskStore(paths).get("T-1").lease
+    assert _wait(lambda: ex.poll(first.worker_id).alive is False), "process never exited"
+
+    rep = rec.reconcile_once()  # observes dead process, no receipt -> adopt
+    assert rep.adopted == ["T-1"]
+    t = TaskStore(paths).get("T-1")
+    assert t.state is TaskState.RUNNING
+    assert t.lease.worker_id != first.worker_id
+    _no_fail(paths)

--- a/tests/test_reconciler.py
+++ b/tests/test_reconciler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -14,6 +15,7 @@ from agent_farm_runtime.adapters.local_process import LocalProcessExecutor
 from agent_farm_runtime.doctor import run_doctor
 from agent_farm_runtime.locking import ReconcilerBusy, single_reconciler
 from agent_farm_runtime.models import Receipt, ReceiptStatus, Task, TaskState
+from agent_farm_runtime.procutil import pid_identity_alive, proc_starttime
 from agent_farm_runtime.reconciler import Reconciler
 from agent_farm_runtime.store import FarmPaths, TaskStore
 from agent_farm_runtime.transitions import (
@@ -361,3 +363,79 @@ def test_single_reconciler_lock_is_exclusive(tmp_path):
     # released -> acquirable again
     with single_reconciler(rt):
         pass
+
+
+def _active_task(tid: str, ws: str) -> Task:
+    return Task(id=tid, objective="o", deliverable="d", acceptance="a",
+                state=TaskState.RUNNING, lease=Lease(f"W-{tid}", f"L-{tid}"),
+                metadata={"workspace": ws})
+
+
+def test_shared_workspace_among_active_tasks_is_rejected(tmp_path):
+    """Two concurrently-active tasks must never share a workspace (their workers
+    would corrupt each other's LEDGER/.session_id). doctor flags it FAIL."""
+    paths = _paths(tmp_path)
+    store = TaskStore(paths)
+    store.create(_active_task("A", "/lab/ws/shared"))
+    store.create(_active_task("B", "/lab/ws/shared"))
+    checks = run_doctor(paths)
+    assert any(c.level == "FAIL" and "shared" in c.message for c in checks)
+    # distinct workspaces are fine
+    store2 = TaskStore(_paths(tmp_path / "other"))
+    store2.create(_active_task("A", "/lab/ws/a"))
+    store2.create(_active_task("B", "/lab/ws/b"))
+    assert not any(c.level == "FAIL" for c in run_doctor(store2.paths))
+
+
+def test_new_ownership_committed_before_stale_worker_stopped(tmp_path):
+    """During adoption the NEW lease must be durably committed BEFORE the stale
+    generation is stopped, so a crash never orphans the task."""
+    paths = _paths(tmp_path)
+    store = TaskStore(paths)
+    store.create(_ready_task())
+    order: list[tuple[str, str]] = []
+
+    class OrderExecutor(FakeExecutor):
+        def stop(self, worker_id):
+            t = store.get("T-1")  # what is durably committed at stop time?
+            order.append(("stop", t.lease.lease_id if t.lease else None))
+            super().stop(worker_id)
+
+        def launch(self, task, lease):
+            order.append(("launch", lease.lease_id))
+            return super().launch(task, lease)
+
+    ex = OrderExecutor()
+    rec = Reconciler(paths, ex, grace_seconds=0)
+    rec.reconcile_once()                      # start gen1
+    first = store.get("T-1").lease
+    ex.kill(first.worker_id)
+    rec.reconcile_once()                      # adopt: commit new -> stop old -> launch new
+
+    stops = [o for o in order if o[0] == "stop"]
+    assert stops, "adoption must stop the stale generation"
+    # the lease committed at stop time is the NEW one, not the dead generation's
+    assert stops[-1][1] == store.get("T-1").lease.lease_id
+    assert stops[-1][1] != first.lease_id
+
+
+def test_pid_identity_rejects_recycled_pid(tmp_path):
+    me = os.getpid()
+    st = proc_starttime(me)
+    assert st is not None
+    assert pid_identity_alive(me, st) is True
+    assert pid_identity_alive(me, st + 987654) is False   # same pid, different process
+    assert pid_identity_alive(2147480000, None) is False  # nonexistent pid
+
+
+def test_local_process_worker_is_reaped_not_zombied(tmp_path):
+    paths = _paths(tmp_path)
+    ex = LocalProcessExecutor(paths.runtime)
+    ex.launch(_ready_task(command="true"), Lease("W-z", "L-z"))  # exits immediately
+    assert _wait(lambda: ex.poll("W-z").alive is False), "worker never exited"
+    pid, _ = ex._identity("W-z")
+    # poll()/stop() reap children, so the exited worker is gone, not a zombie
+    if pid is not None and os.path.exists(f"/proc/{pid}"):
+        stat = Path(f"/proc/{pid}/stat").read_text()
+        state = stat[stat.rindex(")") + 2]
+        assert state != "Z", "exited worker left as a zombie"


### PR DESCRIPTION
Turns the shadow-first runtime into one that actually drives disposable workers,
without breaking the frozen v0.2 safety model. Validated by a real-codex canary
(runtime drove a live worker READY→DONE; live farm untouched).

## What's new
- **Reconciler** (`reconcile_once`): serialized idempotent control pass (INV-6) —
  actuate READY, apply fenced receipts, adopt crashed workers, resume unblocked
  WAITING, repair the observed registry. All state mutation via transitions.
- **Receipt primitive** (RUNNING/AWAITING/SUBMITTED/FAILED) fenced by `lease_id`:
  a superseded worker generation can never advance a task (INV-5).
- **Lease rotation** (`rotate_lease`): release a lease only from a PROVEN-DEAD
  holder → the "adopt a stopped task" primitive. **Design delta beyond frozen
  v0.2** (state graph froze before actuation); to be ratified into v0.3.
- **Executors**: FakeExecutor (tests), LocalProcessExecutor (real subprocess),
  **CodexTmuxExecutor** (real farm backend — faithful port of RESTART_HEADLESS.sh
  + WAKE.sh). Safety: dedicated `-L` tmux server (isolates from a live farm on
  the same host), never kills/moves windows, all tmux/pgrep injectable.
- `farm reconcile --executor {local-process,codex-tmux}` + task-create metadata.
- DONE still requires master acceptance (Layer-1/Layer-2 boundary).

## Tests
25 pass: happy path, WAITING/resume, receipt fencing (fake + real codex),
crash adoption (fake + real dead process), lease guards, tmux-socket isolation,
rendered-script `bash -n` with adversarial quoting.

## Not yet
Crash canary against a live codex worker; WAITING-condition observers; SLURM
mutation; enforcement against non-cooperative workers.