### PR TITLE
Add WAITING unblock observer (nudger replacement) for legion operation

### DIFF
--- a/src/agent_farm_runtime/cli.py
+++ b/src/agent_farm_runtime/cli.py
@@ -84,7 +84,11 @@ def cmd_reconcile(args: argparse.Namespace) -> int:
     else:
         from .adapters.local_process import LocalProcessExecutor
         executor = LocalProcessExecutor(paths.runtime)
-    reconciler = Reconciler(paths, executor, grace_seconds=args.grace_seconds)
+    unblock = None
+    if args.auto_unblock:
+        from .observers import make_unblock
+        unblock = make_unblock(paths)
+    reconciler = Reconciler(paths, executor, grace_seconds=args.grace_seconds, unblock=unblock)
 
     def one_pass() -> None:
         rep = reconciler.reconcile_once()
@@ -174,6 +178,10 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--tmux-socket", default=None, help="dedicated tmux server socket (-L) for isolation")
     p.add_argument("--grace-seconds", type=float, default=60.0,
                    help="seconds a leased worker may be unobserved before its lease is rotated")
+    p.add_argument("--auto-unblock", dest="auto_unblock", action="store_true", default=True,
+                   help="resume WAITING tasks whose named job/artifact/task condition is met (default on)")
+    p.add_argument("--no-auto-unblock", dest="auto_unblock", action="store_false",
+                   help="do not auto-resume WAITING tasks (master resumes them)")
     p.add_argument("--loop", action="store_true", help="run continuously instead of one pass")
     p.add_argument("--interval", type=float, default=10.0, help="seconds between passes in --loop")
     p.set_defaults(func=cmd_reconcile)

--- a/src/agent_farm_runtime/observers.py
+++ b/src/agent_farm_runtime/observers.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+from .models import Task, TaskState
+from .shadow import slurm_state
+from .store import FarmPaths, TaskStore
+
+# The mechanical WAITING->RUNNING unblock predicate: the runtime's replacement
+# for the live farm's nudger. It evaluates ONLY explicit, named conditions
+# recorded in metadata.waiting_on (INV-4: state, not clock). It makes no
+# scientific judgment; `ruling:` conditions are intentionally left to the master.
+#
+# Supported waiting_on forms:
+#   job:<id>            unblock when the SLURM job is no longer in the queue (ended)
+#   job:<id>:start      unblock when the SLURM job is RUNNING
+#   artifact:/abs/path  unblock when the path exists
+#   file:/abs/path      alias of artifact:
+#   task:<id>[#...]     unblock when task <id> is DONE
+#   ruling:<name>       NEVER auto-unblocked here — the master decides (returns False)
+
+SlurmState = Callable[[str], "str | None"]
+
+
+def evaluate_waiting_on(
+    waiting_on: str | None,
+    *,
+    store: TaskStore,
+    slurm: SlurmState = slurm_state,
+) -> bool:
+    if not waiting_on:
+        return False
+    kind, _, rest = waiting_on.partition(":")
+    if kind == "job":
+        job_id, _, mode = rest.partition(":")
+        if not job_id:
+            return False
+        state = slurm(job_id)
+        if mode == "start":
+            return state == "RUNNING"
+        # default: wait for END — unblock once the job leaves the queue
+        return state is None
+    if kind in ("artifact", "file"):
+        return bool(rest) and Path(rest).exists()
+    if kind == "task":
+        dep = rest.split("#", 1)[0]
+        if not dep:
+            return False
+        try:
+            return store.get(dep).state is TaskState.DONE
+        except Exception:
+            return False
+    # ruling:<name> and anything else -> the master's call, not mechanical
+    return False
+
+
+def make_unblock(
+    paths: FarmPaths, *, slurm: SlurmState = slurm_state
+) -> Callable[[Task], bool]:
+    """Build the reconciler's unblock predicate for a farm's Task Store."""
+    store = TaskStore(paths)
+
+    def unblock(task: Task) -> bool:
+        return evaluate_waiting_on(task.metadata.get("waiting_on"), store=store, slurm=slurm)
+
+    return unblock

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_farm_runtime.adapters.fake import FakeExecutor
+from agent_farm_runtime.models import Receipt, ReceiptStatus, Task, TaskState
+from agent_farm_runtime.observers import evaluate_waiting_on, make_unblock
+from agent_farm_runtime.reconciler import Reconciler
+from agent_farm_runtime.store import FarmPaths, TaskStore
+
+
+def _paths(tmp: Path) -> FarmPaths:
+    p = FarmPaths(tmp / ".farm")
+    p.ensure()
+    return p
+
+
+def _ready(tid="T-1", **meta) -> Task:
+    return Task(id=tid, objective="o", deliverable="d", acceptance="a", metadata=dict(meta))
+
+
+def test_job_end_unblocks_when_job_leaves_queue(tmp_path):
+    store = TaskStore(_paths(tmp_path))
+    # still queued -> blocked; gone -> unblocked
+    assert evaluate_waiting_on("job:123", store=store, slurm=lambda j: "RUNNING") is False
+    assert evaluate_waiting_on("job:123", store=store, slurm=lambda j: None) is True
+
+
+def test_job_start_unblocks_when_running(tmp_path):
+    store = TaskStore(_paths(tmp_path))
+    assert evaluate_waiting_on("job:123:start", store=store, slurm=lambda j: None) is False
+    assert evaluate_waiting_on("job:123:start", store=store, slurm=lambda j: "RUNNING") is True
+
+
+def test_artifact_unblocks_when_path_exists(tmp_path):
+    store = TaskStore(_paths(tmp_path))
+    art = tmp_path / "out.txt"
+    assert evaluate_waiting_on(f"artifact:{art}", store=store) is False
+    art.write_text("done")
+    assert evaluate_waiting_on(f"artifact:{art}", store=store) is True
+
+
+def test_task_dep_unblocks_when_done(tmp_path):
+    paths = _paths(tmp_path)
+    store = TaskStore(paths)
+    dep = _ready("T-dep")
+    dep.state = TaskState.SUBMITTED
+    store.create(dep)
+    assert evaluate_waiting_on("task:T-dep#deliverable", store=store) is False
+    dep.state = TaskState.DONE
+    dep.metadata["acceptance_receipt"] = "x"
+    store.put_authoritative(dep)
+    assert evaluate_waiting_on("task:T-dep", store=store) is True
+
+
+def test_ruling_is_never_auto_unblocked(tmp_path):
+    store = TaskStore(_paths(tmp_path))
+    assert evaluate_waiting_on("ruling:MR_009", store=store) is False
+    assert evaluate_waiting_on(None, store=store) is False
+
+
+def test_reconciler_auto_resumes_on_job_end(tmp_path):
+    paths = _paths(tmp_path)
+    TaskStore(paths).create(_ready())
+    ex = FakeExecutor()
+    queued = {"v": True}
+    unblock = make_unblock(paths, slurm=lambda j: "RUNNING" if queued["v"] else None)
+    rec = Reconciler(paths, ex, unblock=unblock)
+
+    rec.reconcile_once()  # launch
+    lease = TaskStore(paths).get("T-1").lease
+    ex.set_receipt(Receipt(lease.worker_id, "T-1", lease.lease_id,
+                           ReceiptStatus.AWAITING, ts="t", waiting_on="job:999"))
+    rec.reconcile_once()  # -> WAITING(job:999)
+    assert TaskStore(paths).get("T-1").state is TaskState.WAITING
+
+    ex.clear_receipt(lease.worker_id)
+    rec.reconcile_once()  # job still queued -> stays WAITING
+    assert TaskStore(paths).get("T-1").state is TaskState.WAITING
+
+    queued["v"] = False   # job ended
+    rep = rec.reconcile_once()
+    assert rep.resumed == ["T-1"]
+    assert TaskStore(paths).get("T-1").state is TaskState.RUNNING


### PR DESCRIPTION
The mechanical WAITING->RUNNING predicate the reconciler needs to drive a real codex legion (the old nudger's job), on a branch off the actuation work so PR #1 stays as-is.

- observers.evaluate_waiting_on / make_unblock: evaluate ONLY explicit named conditions in metadata.waiting_on (INV-4): job:<id> (ended / :start), artifact:/file: (path exists), task:<id> (dep DONE). ruling:<name> is NEVER auto-unblocked -- that stays the master's decision.
- `farm reconcile` wires it by default (--no-auto-unblock to disable); the predicate reuses shadow.slurm_state (read-only squeue/sacct).
- 6 tests incl. reconciler auto-resume on job end. 44 pass total.